### PR TITLE
Show error when the user tries neo.py update in a detached HEAD state...

### DIFF
--- a/neo.py
+++ b/neo.py
@@ -961,8 +961,9 @@ def sync(recursive=True, keep_refs=False, top=True):
 
     if recursive:
         for lib in repo.libs:
-            with cd(lib.path):
-                sync(keep_refs=keep_refs, top=False)
+            if os.path.isdir(lib.path):
+                with cd(lib.path):
+                    sync(keep_refs=keep_refs, top=False)
 
             
 @subcommand('ls',


### PR DESCRIPTION
...and encourage to manually switch to a branch (gits behavior in detached state)

Fixed issue #58 and also allow keeping of orphaned references (.lib without clone repo) during update to allow import behavior
