### PR TITLE
Move to non-truncated hashes in lib files

### DIFF
--- a/neo.py
+++ b/neo.py
@@ -419,7 +419,7 @@ class Git(object):
         return url
 
     def gethash(repo):
-        return pquery([git_cmd, 'rev-parse', '--short=12', 'HEAD']).strip()
+        return pquery([git_cmd, 'rev-parse', 'HEAD']).strip()
 
     def ignores(repo):
         with open(os.path.join(repo.path, '.git/info/exclude'), 'w') as f:

--- a/test/util.py
+++ b/test/util.py
@@ -152,7 +152,7 @@ def teststructure(neo, request):
         with open('test4.lib', 'w') as f:
             with cd('test4'):
                 if scm() == 'git':
-                    hash = pquery(['git', 'rev-parse', '--short=12', 'HEAD'])
+                    hash = pquery(['git', 'rev-parse', 'HEAD'])
                 elif scm() == 'hg':
                     hash = pquery(['hg', 'id', '-i'])
             f.write(test4 + '/#' + hash + '\n')
@@ -170,7 +170,7 @@ def teststructure(neo, request):
         with open('test3.lib', 'w') as f:
             with cd('test3'):
                 if scm() == 'git':
-                    hash = pquery(['git', 'rev-parse', '--short=12', 'HEAD'])
+                    hash = pquery(['git', 'rev-parse', 'HEAD'])
                 elif scm() == 'hg':
                     hash = pquery(['hg', 'id', '-i'])
             f.write(test3 + '/#' + hash + '\n')
@@ -188,7 +188,7 @@ def teststructure(neo, request):
         with open('test2.lib', 'w') as f:
             with cd('test2'):
                 if scm() == 'git':
-                    hash = pquery(['git', 'rev-parse', '--short=12', 'HEAD'])
+                    hash = pquery(['git', 'rev-parse', 'HEAD'])
                 elif scm() == 'hg':
                     hash = pquery(['hg', 'id', '-i'])
             f.write(test2 + '/#' + hash + '\n')


### PR DESCRIPTION
@meriac made the point that shorter hashes are vulnerable to collisions.
And although git rev-parse handles this gracefully, storing references
to short hashes can prove to be problematic unless the history is walked
to lookup the full hashes.

Using an arbitrary length, although sufficient, imposes an arbitrary
constraint that I don't understand the reason for. Since .lib files are hidden
from the user, I see no reason to not simply store the full hashes.
