### PR TITLE
Use short hashes for neo ls

### DIFF
--- a/neo.py
+++ b/neo.py
@@ -961,7 +961,12 @@ def sync(recursive=True, top=True):
     help='View the current %s dependency tree.' % cwd_type)
 def list_(all=False, prefix=''):
     repo = Repo.fromrepo()
-    print prefix + repo.name, '(%s)' % (repo.url if all else repo.hash)
+
+    if all:
+        print '%s%s' % (prefix, repo.fullurl)
+    else:
+        print '%s%s (%s)' % (prefix, repo.name, 
+            repo.hash[:7] if repo.scm.name == 'git' else repo.hash)
 
     for i, lib in enumerate(sorted(repo.libs, key=lambda l: l.name)):
         if prefix:


### PR DESCRIPTION
Short hashes provide a user-friendly method of identifying
specific commits. Full hashes are still provided if the
-a/--all flag is provided.
