### PR TITLE
URL consistency and protocol selection when importing/adding/updating etc

### DIFF
--- a/neo.py
+++ b/neo.py
@@ -1152,6 +1152,11 @@ try:
     status = args.command(args)
 except ProcessException as e:
     error('Subrocess exit with error code %d' % e[0], e[0])
+except OSError as e:
+    if e[0] == 2:
+        error('Could not detect one of the command-line tools.\nPlease verify that you have Git and Mercurial installed and accessible from your current path by executing commands "git" and "hg".\nHint: check the last executed command above.', e[0])
+    else:
+        error('OS Error: %s' % e[1], e[0])
 except KeyboardInterrupt as e:
     error('User aborted!', 255)
 


### PR DESCRIPTION
Introduce formaturl() routine which helps keep consistency between 4 repository URL formats - https, http, ssh and git.

The commands below are cloning one same thing:
`neo.py import https://github.com/ARMmbed/mbed-os/`
`neo.py import http://github.com/ARMmbed/mbed-os/`
`neo.py import ssh://github.com/ARMmbed/mbed-os.git`
`neo.py import git@github.com:ARMmbed/mbed-os.git`
Through this routine, the references in .lib files will be consistent.

Also introduce --protocol option to import,deploy,add and update, so users can select their preferred protocol when working with the repositories they import. The example below will clone repositories through ssh, based on GitHub's ssh formatted URLs.

`neo.py import https://github.com/ARMmbed/example-mbedos-blinky/ --protocol git`
