### PR TITLE
Compilation of tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,13 @@ The compiled binary (and ELF image) can be found in the `.build` subdirectory of
 
 ### Compiling Tests
 
-Tests are compiled with the module source. Test code exists in following directory structure
+Tests are compiled by adding argument ```--tests``` in the above compile command:
+
+```
+$ neo.py compile -t ARM -m K64F --tests -j 0
+```
+
+Test code exists in following directory structure
 
 ```
 <module>

--- a/neo.py
+++ b/neo.py
@@ -679,7 +679,7 @@ def subcommand(name, *args, **kwargs):
                 subparser.add_argument(*opt, **arg)
     
         def thunk(parsed_args):
-            argv = [arg['name'] for arg in args]
+            argv = [arg['dest'] if 'dest' in arg else arg['name'] for arg in args]
             argv = [(arg if isinstance(arg, basestring) else arg[-1]).strip('-')
                     for arg in argv]
             argv = {arg: vars(parsed_args)[arg] for arg in argv
@@ -1000,8 +1000,9 @@ def status():
 @subcommand('compile',
     dict(name=['-t', '--toolchain'], help="Compile toolchain. Example: ARM, uARM, GCC_ARM, IAR"),
     dict(name=['-m', '--mcu'], help="Compile target. Example: K64F, NUCLEO_F401RE, NRF51822..."),
+    dict(name='--tests', dest="compile_tests", action="store_true", help="Compile tests in TESTS directory."),
     help='Compile program using the native mbed OS build system.')
-def compile(toolchain=None, mcu=None):
+def compile(toolchain=None, mcu=None, compile_tests=False):
     root_path = Repo.findroot(os.getcwd())
     if not root_path:
         Repo.fromrepo()
@@ -1047,23 +1048,24 @@ def compile(toolchain=None, mcu=None):
             action("Skipping module compilation as it is a library!")
 
         # Compile tests
-        tests_path = 'TESTS'
-        if os.path.exists(tests_path):
-            # Loop on test group directories
-            for d in os.listdir(tests_path):
-                # dir name host_tests is reserved for host python scripts.
-                if d != "host_tests":
-                    # Loop on test case directories
-                    for td in os.listdir(os.path.join(tests_path, d)):
-                        # compile each test
-                        popen(['python', os.path.join(mbed_os_path, 'tools', 'make.py')]
-                            + list(chain.from_iterable(izip(repeat('-D'), macros)))
-                            + ['-t', tchain, '-m', target]
-                            + ['--source=%s' % os.path.join(tests_path, d, td), '--source=.']
-                            + ['--build=%s' % os.path.join('.build', target, tchain)]
-                            + args,
-                            env=env)
-                        if "-c" in args: args.remove('-c')
+        if compile_tests:
+            tests_path = 'TESTS'
+            if os.path.exists(tests_path):
+                # Loop on test group directories
+                for d in os.listdir(tests_path):
+                    # dir name host_tests is reserved for host python scripts.
+                    if d != "host_tests":
+                        # Loop on test case directories
+                        for td in os.listdir(os.path.join(tests_path, d)):
+                            # compile each test
+                            popen(['python', os.path.join(mbed_os_path, 'tools', 'make.py')]
+                                + list(chain.from_iterable(izip(repeat('-D'), macros)))
+                                + ['-t', tchain, '-m', target]
+                                + ['--source=%s' % os.path.join(tests_path, d, td), '--source=.']
+                                + ['--build=%s' % os.path.join('.build', target, tchain)]
+                                + args,
+                                env=env)
+                            if "-c" in args: args.remove('-c')
 
         
 # Export command


### PR DESCRIPTION
Fix for https://github.com/ARMmbed/neo/issues/68

Added basic functionality in neo to compile tests in a module. It also enabled compilation of lib modules. Hence also fixes the need of https://github.com/ARMmbed/neo/issues/63

Test identification specification is:
- Tests will be inside case in-sensitive `tests` dir inside the module being compiled.
- There can be any depth dirs inside the `tests` dir. 
- Directories inside a directory containing test code will be ignored considering they may contain factored code of same test.
