### PR TITLE
Removing trailing slashes for repo urls

### DIFF
--- a/neo.py
+++ b/neo.py
@@ -666,25 +666,25 @@ def formaturl(url, format="default"):
     url = "%s" % url
     m = re.match(regex_mbed_url, url)
     if m:
-        url = 'https://mbed.org/'+m.group(4)+'/'+m.group(5)+'/code/'+m.group(7)+'/'
+        url = 'https://mbed.org/'+m.group(4)+'/'+m.group(5)+'/code/'+m.group(7)
     else:
         m = re.match(regex_git_url, url)
         if m:
             if format == "ssh":
                 url = 'ssh://%s/%s.git' % (m.group(2), m.group(3))
             elif format == "http":
-                url = 'http://%s/%s/' % (m.group(2), m.group(3))
+                url = 'http://%s/%s' % (m.group(2), m.group(3))
             else:
-                url = 'https://%s/%s/' % (m.group(2), m.group(3)) # https is default
+                url = 'https://%s/%s' % (m.group(2), m.group(3)) # https is default
         else:
             m = re.match(regex_hg_url, url)
             if m:
                 if format == "ssh":
-                    url = 'ssh://%s/%s/' % (m.group(2), m.group(3))
+                    url = 'ssh://%s/%s' % (m.group(2), m.group(3))
                 elif format == "http":
-                    url = 'http://%s/%s/' % (m.group(2), m.group(3))
+                    url = 'http://%s/%s' % (m.group(2), m.group(3))
                 else:
-                    url = 'https://%s/%s/' % (m.group(2), m.group(3)) # https is default
+                    url = 'https://%s/%s' % (m.group(2), m.group(3)) # https is default
     return url
 
 


### PR DESCRIPTION
In Git version 2.7.4 (the version currently in use by CircleCI), cloning a repository from a url with a trailing slash is not supported. This is not an issue in Git versions 1.9.1 (and most likely 1.9.x in general), which is why this probably wasn't caught on my local machine.

Problem URL: `https://github.com/ARMmbed/uvisor-mbed-lib/`
OK URL: `https://github.com/ARMmbed/uvisor-mbed-lib`

This PR standardizes all repo URLs to not have a trailing slash.
