### PR TITLE
Cleaner and verbose output

### DIFF
--- a/neo.py
+++ b/neo.py
@@ -831,7 +831,7 @@ def new(name, scm='git', depth=None, protocol=None):
             sync()
     else:       # It's a program. Add mbed-os
         # This helps sub-commands to display relative paths to the created program
-        cwd_root = d_path
+        cwd_root = os.path.abspath(d_path)
         
         try:
             with cd(d_path):


### PR DESCRIPTION
This set of patches do 2 things:
1. It makes the default `neo` output to a much a cleaner, easy to read text by reducing neo's own messages, but also by passing -q (--quiet) flag to backend SCMs. See example output below.
2. Add -v/--verbose switch to neo which significantly increases the output messages and also the -v flag is passed to the relevant SCMs

Example of cleaner output

```
>neo.py new my-new-program
[neo.py] Creating new program "my-new-program" (git)
[neo.py] Adding library "mbed-os" from "https://github.com/ARMmbed/mbed-os/"
[neo.py] Adding library "mbed-os\core\mbedtls" from "https://mbed.org/teams/sandbox/code/mbedtls/" at rev #bef26f687287
[neo.py] Adding library "mbed-os\core\uvisor-mbed-lib" from "https://github.com/ARMmbed/uvisor-mbed-lib/" at rev #32b6df4a39df
[neo.py] Adding library "mbed-os\frameworks\greentea-client" from "https://github.com/bridadan/greentea-client/" at rev #398d96e25630
[neo.py] Adding library "mbed-os\net\atmel-rf-driver" from "https://github.com/ARMmbed/atmel-rf-driver-mirror/" at rev #f4c48e5e98f6
[neo.py] Adding library "mbed-os\net\coap-service" from "https://github.com/ARMmbed/coap-service-mirror/" at rev #0c7805098970
[neo.py] Adding library "mbed-os\net\mbed-client-c" from "https://github.com/ARMmbed/mbed-client-c-mirror/" at rev #753541105a6f
[neo.py] Adding library "mbed-os\net\mbed-client-classic" from "https://github.com/ARMmbed/mbed-client-classic/" at rev #0cf03c143a2a
[neo.py] Adding library "mbed-os\net\mbed-client-mbedtls" from "https://github.com/ARMmbed/mbed-client-mbedtls-mirror/" at rev #582821c96be8
[neo.py] Adding library "mbed-os\net\mbed-client-randlib" from "https://github.com/ARMmbed/mbed-client-randlib-mirror/" at rev #237b3fa0255f
[neo.py] Adding library "mbed-os\net\mbed-client" from "https://github.com/ARMmbed/mbed-client-mirror/" at rev #2a839d6c5bef
[neo.py] Adding library "mbed-os\net\mbed-mesh-api" from "https://github.com/ARMmbed/mbed-mesh-api-mirror/" at rev #f7a198bb1e66
[neo.py] Adding library "mbed-os\net\mbed-trace" from "https://github.com/ARMmbed/mbed-trace-mirror/" at rev #f9a11fcaa2b5
[neo.py] Adding library "mbed-os\net\nanostack-hal-mbed-cmsis-rtos" from "https://github.com/ARMmbed/nanostack-hal-mbed-cmsis-rtos/" at rev #ab64e255deb9
[neo.py] Adding library "mbed-os\net\nanostack-libservice" from "https://github.com/ARMmbed/nanostack-libservice-mirror/" at rev #e3f7da74a143
[neo.py] Adding library "mbed-os\net\sal-iface-6lowpan-morpheus-private" from "https://github.com/ARMmbed/sal-iface-6lowpan-morpheus-private-mirror/" at rev #2b4852e22679
[neo.py] Adding library "mbed-os\net\sal-stack-nanostack-eventloop" from "https://github.com/ARMmbed/sal-stack-nanostack-eventloop-mirror/" at rev #627b9769e352
[neo.py] Adding library "mbed-os\net\sal-stack-nanostack-private" from "https://github.com/ARMmbed/sal-stack-nanostack-private-mirror/" at rev #1374c77b03fb
[neo.py] Updating reference "mbed-os" -> "https://github.com/ARMmbed/mbed-os/#e472a51e45f30d793cbb430b6ebf3e1c53d82f57"
```
