### PR TITLE
Can compile within mbed-os directory

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1201,7 +1201,7 @@ def compile(toolchain=None, mcu=None, compile_tests=False):
         env['PYTHONPATH'] = '.'
 
         # Only compile a program
-        if mbed_os_path == 'mbed-os':
+        if mbed_os_path in ['mbed-os', '.']:
             popen(['python', os.path.join(mbed_os_path, 'tools', 'make.py')]
                 + list(chain.from_iterable(izip(repeat('-D'), macros)))
                 + ['-t', tchain, '-m', target, '--source=.', '--build=%s' % os.path.join('.build', target, tchain)]


### PR DESCRIPTION
Response for https://github.com/ARMmbed/mbed-cli/issues/96.

While building from withing mbed-os dir <command better knows as neo> skips mbed-os build.

Example:

```
$ git clone https://github.com/ARMmbed/mbed-os.git
$ cd mbed-os
$ pwd
$ c:\Work\stuff\mbed-os
$ neo compile 
[mbed] Skipping module compilation as it is a library!
```

Changes:
- Add '.' dir as correct for mbed-os build
