### PR TITLE
Moved settings file out of source control folder

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -58,6 +58,7 @@ ignores = [
     "*.htm",
     
     # Settings files
+    ".mbed",
     "*.settings",
     "mbed_settings.py",
     
@@ -1184,7 +1185,7 @@ def compile(toolchain=None, mcu=None, source=False, build=False, compile_library
             error('The mbed-os codebase and tools were not found.', -1)
 
         repo = Repo.fromrepo()
-        file = os.path.join('.mbed.settings')
+        file = os.path.join('.mbed')
 
         target = mcu if mcu else get_cfg(file, 'TARGET')
         if target is None:
@@ -1308,7 +1309,7 @@ def export(ide=None, mcu=None):
 
         args = remainder
         repo = Repo.fromrepo()
-        file = os.path.join('.mbed.settings')
+        file = os.path.join('.mbed')
         
         target = mcu if mcu else get_cfg(file, 'TARGET')
         if target is None:
@@ -1336,7 +1337,7 @@ def target(name=None):
     root_path = Repo.findroot(os.getcwd())
     with cd(root_path):
         repo = Repo.fromrepo()
-        file = os.path.join('.mbed.settings')
+        file = os.path.join('.mbed')
         if name is None:
             name = get_cfg(file, 'TARGET')
             action(('The default target for program "%s" is "%s"' % (repo.name, name)) if name else 'No default target is specified for program "%s"' % repo.name)
@@ -1351,7 +1352,7 @@ def toolchain(name=None):
     root_path = Repo.findroot(os.getcwd())
     with cd(root_path):
         repo = Repo.fromrepo()        
-        file = os.path.join('.mbed.settings')
+        file = os.path.join('.mbed')
         if name is None:
             name = get_cfg(file, 'TOOLCHAIN')
             action(('The default toolchain for program "%s" is "%s"' % (repo.name, name)) if name else 'No default toolchain is specified for program "%s"' % repo.name)


### PR DESCRIPTION
This change puts the build settings file in a consistent location (and out of folders under 3rd party control) to allow easier parsing by external processes.

The name of the file `.mbed.settings` is a best guess, using a `.` to hide it from the file system and the `.settings` extension as it is already ignored during deploy.

The new file isn't ignored by standard git/hg commands, however and I'm wondering whether the `mbed-cli new` command should create a default ignore file for SCMs.
