### PR TITLE
Test compile from mbed tools

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1233,7 +1233,7 @@ def status(ignore=False):
     dict(name='--build', help="Build directory. Default: .build/"),
     dict(name='--library', dest="compile_library", action="store_true", help="Compile the current %s as a static library." % cwd_type),
     dict(name='--tests', dest="compile_tests", action="store_true", help="Compile tests in TESTS directory."),
-    dict(name='--test_spec', dest="test_spec", help="Destination path for a test spec file that can be used by the Greentea automated test tool"),
+    dict(name='--test_spec', dest="test_spec", help="Destination path for a test spec file that can be used by the Greentea automated test tool. (Default is 'test_spec.json')"),
     help='Compile program using the native mbed OS build system.')
 def compile(toolchain=None, mcu=None, source=False, build=False, compile_library=False, compile_tests=False, test_spec="test_spec.json"):
     args = remainder


### PR DESCRIPTION
This PR moves the building logic for tests completely into the mbed-os `tools` directory by making use of the `test.py` script.

It also manages the build directory of the tests and creates a test spec file that can be used by greentea for running tests.

You can run the tests with this test spec using the latest greentea and the command `mbegt --test-spec=test_spec.json`
