### PR TITLE
Require user to install Mercurial

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This document covers the installation and usage of *mbed CLI*.
 
 * *mbed-cli* is a Python script, so you'll need Python installed in order to use it. *mbed-cli* was tested with [version 2.7 of Python](https://www.python.org/download/releases/2.7/).
 
-* *mbed-cli* supports both Git and Mercurial repositories, so you'll also need to install one or both:
+* *mbed-cli* supports both Git and Mercurial repositories, you'll need to install both:
     * [Mercurial](https://www.mercurial-scm.org/).
     * [Git](https://git-scm.com/).
 	


### PR DESCRIPTION
|[mbed] Couldn't find build tools in your program. Downloading the mbed SDK tools...
[mbed ERROR] Could not execute "hg".
## [mbed ERROR] Please verify that it's installed and accessible from your current path by executing "hg".

Traceback (most recent call last):
  File "/usr/local/bin/mbed", line 9, in <module>
    load_entry_point('mbed-cli==0.3.1', 'console_scripts', 'mbed')()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/**init**.py", line 542, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/**init**.py", line 2569, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/**init**.py", line 2229, in load
    return self.resolve()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/**init**.py", line 2235, in resolve
    module = **import**(self.module_name, fromlist=['**name**'], level=0)
  File "build/bdist.linux-x86_64/egg/mbed/mbed.py", line 1811, in <module>
  File "build/bdist.linux-x86_64/egg/mbed/mbed.py", line 1246, in thunk
  File "build/bdist.linux-x86_64/egg/mbed/mbed.py", line 1301, in new
  File "build/bdist.linux-x86_64/egg/mbed/mbed.py", line 1137, in post_action
  File "build/bdist.linux-x86_64/egg/mbed/mbed.py", line 1180, in get_tools
Exception: (128, 'An error occurred while cloning the mbed SDK tools from "https://mbed.org/users/mbed_official/code/mbed-sdk-tools"')

This is also potentially an unhandled exception bug. Depending if you want mbed-cli to handle errors gracefully.
