### PR TITLE
Add command 'detect' and -S/--supported to `mbed compile`

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1840,7 +1840,7 @@ def export(ide=None, mcu=None):
 # Test command
 @subcommand('detect',
     help='Detect mbed targets/boards connected to this system.')
-def test(tlist=False):
+def detect():
     # Gather remaining arguments
     args = remainder
     # Find the root of the program


### PR DESCRIPTION
This PR adds:
- command 'detect' which takes advantage of mbed-ls and the tools/detect_targets.py script
- switch -S/--supported to `mbed compile` to show all supported targets
