### PR TITLE
Fixing order of pip install message

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1208,7 +1208,7 @@ class Program(object):
                 "The mbed build tools in this program require Python modules that are not installed.\n"
                 "This might prevent compiling code or exporting to IDEs and other toolchains.\n"
                 "The missing Python modules are: %s\n"
-                "You can install all missing modules by running \"pip install -r %s\" in \"%s\"" % (', '.join(missing), mbed_os_path, fname))
+                "You can install all missing modules by running \"pip install -r %s\" in \"%s\"" % (', '.join(missing), fname, mbed_os_path))
 
     def add_tools(self, path):
         with cd(path):


### PR DESCRIPTION
This is a small change to the warning that is printed when the required python packages are not installed.

The file `requirements.txt` and the `mbed-os` path were flipped.

Priority: LOW
