### PR TITLE
Respecting --test-spec definition for test command

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2010,6 +2010,8 @@ def test_(toolchain=None, mcu=None, compile_list=False, run_list=False, compile_
     args = remainder
     # Find the root of the program
     program = Program(os.getcwd(), True)
+    # Save original working directory
+    orig_path = os.getcwd()
 
     target = program.get_mcu(mcu)
     tchain = program.get_toolchain(toolchain)
@@ -2029,8 +2031,13 @@ def test_(toolchain=None, mcu=None, compile_list=False, run_list=False, compile_
         if not build:
             build = os.path.join(program.path, '.build/tests', target, tchain)
 
-        # Create the path to the test spec file
-        test_spec = os.path.join(build, 'test_spec.json')
+        
+        if test_spec:
+            # Preserve path to given test spec
+            test_spec = os.path.relpath(os.path.join(orig_path, test_spec), program.path)
+        else:
+            # Create the path to the test spec file
+            test_spec = os.path.join(build, 'test_spec.json')
 
         if compile_list:
             popen(['python', '-u', os.path.join(tools_dir, 'test.py'), '--list']


### PR DESCRIPTION
This PR address issue https://github.com/ARMmbed/mbed-cli/issues/252.

Previously, the `--test-spec` option was not being respected. This fixes this behaviour.
## Before

Notice how the test spec is not placed in the correct directory nor named correctly.

```
C:\m\test>mbed test --test-spec=my_test_spec_hurdur.xml -n mbed-os-tests-mbedmicro-rtos-mbed-mutex -v
[mbed] Working path "C:\m\test" (program)
[mbed] Exec "python -u C:\m\test\mbed-os\core\tools\test.py -t GCC_ARM -m K64F --source C:\m\test --build C:\m\test\.build/tests\K64F\GCC_ARM --test-spec C:\m\test\.build/tests\K64F\GCC_ARM\test_spec.json -n mbed-os-tests-mbedmicro-rtos-mbed-mutex -v" in C:\m\test

Build successes:
  * K64F::GCC_ARM::MBED-BUILD
  * K64F::GCC_ARM::MBED-OS-TESTS-MBEDMICRO-RTOS-MBED-MUTEX
[mbed] Exec "mbedgt --test-spec C:\m\test\.build/tests\K64F\GCC_ARM\test_spec.json -n mbed-os-tests-mbedmicro-rtos-mbed-mutex -V" in C:\m\test
mbedgt: test specification file 'C:\m\test\.build/tests\K64F\GCC_ARM\test_spec.json' (specified with --test-spec option)
mbedgt: using 'C:\m\test\.build/tests\K64F\GCC_ARM\test_spec.json' from current directory!
mbedgt: test case results: 1 OK
mbedgt: completed in 23.92 sec
```
## After

The test spec is now placed in the correct directory and named correctly.

```
C:\m\test>mbed test --test-spec=my_test_spec_hurdur.xml -n mbed-os-tests-mbedmicro-rtos-mbed-mutex -v
[mbed] Working path "C:\m\test" (program)
[mbed] Exec "python -u C:\m\test\mbed-os\core\tools\test.py -t GCC_ARM -m K64F --source C:\m\test --build C:\m\test\.build/tests\K64F\GCC_ARM --test-spec my_test_spec_hurdur.xml -n mbed-os-tests-mbedmicro-rtos-mbed-mutex -v" in C:\m\test

Build successes:
  * K64F::GCC_ARM::MBED-BUILD
  * K64F::GCC_ARM::MBED-OS-TESTS-MBEDMICRO-RTOS-MBED-MUTEX
[mbed] Exec "mbedgt --test-spec my_test_spec_hurdur.xml -n mbed-os-tests-mbedmicro-rtos-mbed-mutex -V" in C:\m\test
mbedgt: test specification file 'my_test_spec_hurdur.xml' (specified with --test-spec option)
mbedgt: using 'my_test_spec_hurdur.xml' from current directory!
mbedgt: test case results: 1 OK
mbedgt: completed in 22.63 sec
```
### Test spec placed in child directory

The test spec is placed in a child directory here.

```
C:\m\test>mbed test --test-spec=projectfiles/my_test_spec_hurdur.xml -n mbed-os-tests-mbedmicro-rtos-mbed-queue -v
[mbed] Working path "C:\m\test" (program)
[mbed] Exec "python -u C:\m\test\mbed-os\core\tools\test.py -t GCC_ARM -m K64F --source C:\m\test --build C:\m\test\.build/tests\K64F\GCC_ARM --test-spec projectfiles\my_test_spec_hurdur.xml -n mbed-os-tests-mbedmicro-rtos-mbed-queue -v" in C:\m\test

Build successes:
  * K64F::GCC_ARM::MBED-BUILD
  * K64F::GCC_ARM::MBED-OS-TESTS-MBEDMICRO-RTOS-MBED-QUEUE
[mbed] Exec "mbedgt --test-spec projectfiles\my_test_spec_hurdur.xml -n mbed-os-tests-mbedmicro-rtos-mbed-queue -V" in C:\m\test
mbedgt: test specification file 'projectfiles\my_test_spec_hurdur.xml' (specified with --test-spec option)
mbedgt: using 'projectfiles\my_test_spec_hurdur.xml' from current directory!
mbedgt: test case results: 1 OK
mbedgt: completed in 13.99 sec
```
### Test spec placed relative to current directory (not project root)

If `mbed test` is executed from a directory other than the project root, the destination of the test spec file is relative to this directory, not the project root.

```
C:\m\test\projectfiles>mbed test --test-spec=my_test_spec_hurdur.xml -n mbed-os-tests-mbedmicro-rtos-mbed-mutex -v
[mbed] Working path "C:\m\test\projectfiles" (program)
[mbed] Exec "python -u C:\m\test\mbed-os\core\tools\test.py -t GCC_ARM -m K64F --source C:\m\test --build C:\m\test\.build/tests\K64F\GCC_ARM --test-spec projectfiles\my_test_spec_hurdur.xml -n mbed-os-tests-mbedmicro-rtos-mbed-mutex -v" in C:\m\test
Build successes:
  * K64F::GCC_ARM::MBED-BUILD
  * K64F::GCC_ARM::MBED-OS-TESTS-MBEDMICRO-RTOS-MBED-MUTEX
[mbed] Exec "mbedgt --test-spec projectfiles\my_test_spec_hurdur.xml -n mbed-os-tests-mbedmicro-rtos-mbed-mutex -V" in C:\m\test
mbedgt: test specification file 'projectfiles\my_test_spec_hurdur.xml' (specified with --test-spec option)
mbedgt: using 'projectfiles\my_test_spec_hurdur.xml' from current directory!
mbedgt: test case results: 1 OK
mbedgt: completed in 22.86 sec
```

Please review @screamerbg 
FYI @mazimkhan 
