### PR TITLE
mbed CLI 0.8.x fixes

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -35,7 +35,7 @@ import argparse
 
 
 # Application version
-ver = '0.8.3'
+ver = '0.8.5'
 
 # Default paths to Mercurial and Git
 hg_cmd = 'hg'

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read(fname):
 setup(
     name="mbed-cli",
     packages=["mbed"],
-    version="0.8.3",
+    version="0.8.5",
     url='http://github.com/ARMmbed/mbed-cli',
     author='ARM mbed',
     author_email='support@mbed.org',


### PR DESCRIPTION
This PR fixes the following:
- Prominently display repository protocol and URL that is used for import/add (clone)
- Fixed handling of 'mbed new' when destination exists, e.g. report error. Also cleanup logic that  determines whether program or library should be created

Also bump version up to 0.8.5
