### PR TITLE
Add missing user field to git clone ssh url

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1369,7 +1369,7 @@ def formaturl(url, format="default"):
         m = re.match(regex_git_url, url)
         if m:
             if format == "ssh":
-                url = 'ssh://%s/%s.git' % (m.group(2), m.group(3))
+                url = 'ssh://git@%s/%s.git' % (m.group(2), m.group(3))
             elif format == "http":
                 url = 'http://%s/%s' % (m.group(2), m.group(3))
             elif format == "https":


### PR DESCRIPTION
for --protocol=ssh mbed-cli tries to guess the url passed to git. However, the _user_ field is not captured in the .lib file (if the url is http based in the .lib) and hence not encoded in the url. ssh will attempt to use the currently logged in user which usually fails. This patch assumes the user to be "git" which allow mbed-cli to work at least with github and other common publicly hosted git systems.
