### PR TITLE
mbed CLI 0.8.5 fixes

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -35,7 +35,7 @@ import argparse
 
 
 # Application version
-ver = '0.8.6'
+ver = '0.8.7'
 
 # Default paths to Mercurial and Git
 hg_cmd = 'hg'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LICENSE = open('LICENSE').read()
 
 setup(
     name="mbed-cli",
-    version="0.8.6",
+    version="0.8.7",
     description="ARM mbed command line tool for repositories version control, publishing and updating code from remotely hosted repositories (GitHub, GitLab and mbed.org), and invoking mbed OS own build system and export functions, among other operations",
     long_description=LONG_DESC,
     url='http://github.com/ARMmbed/mbed-cli',


### PR DESCRIPTION
This PR fixes:
- Handling of mbed CLI when imported as python module
- Handling of OS/permission errors when trying to writing global config in the user home directory
- Fixed authentication for Git repository URLs
- Fixed detection of programs that need external tools but do not have .bld file (e.g. Microbit projects)
