### PR TITLE
mbed CLI 0.8.7 fixes

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -35,7 +35,7 @@ import argparse
 
 
 # Application version
-ver = '0.8.7'
+ver = '0.8.8'
 
 # Default paths to Mercurial and Git
 hg_cmd = 'hg'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LICENSE = open('LICENSE').read()
 
 setup(
     name="mbed-cli",
-    version="0.8.7",
+    version="0.8.8",
     description="ARM mbed command line tool for repositories version control, publishing and updating code from remotely hosted repositories (GitHub, GitLab and mbed.org), and invoking mbed OS own build system and export functions, among other operations",
     long_description=LONG_DESC,
     url='http://github.com/ARMmbed/mbed-cli',


### PR DESCRIPTION
Fixed
- Correctly match Git authentication in URL references. This is related to #289 
