### PR TITLE
Passing -t and -m to test.py for --compile-list option

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2058,6 +2058,7 @@ def test_(toolchain=None, mcu=None, compile_list=False, run_list=False, compile_
 
         if compile_list:
             popen(['python', '-u', os.path.join(tools_dir, 'test.py'), '--list']
+                  + ['-t', tchain, '-m', target]
                   + (['-n', tests_by_name] if tests_by_name else [])
                   + (['-v'] if verbose else [])
                   + args,


### PR DESCRIPTION
Previously, test discovery didn't take into account the target and toolchain when scanning for tests. All tests always ran for all target and toolchain combinations.

In order to support having tests under `FEATURE_`, `TARGET_`, and `TOOLCHAIN_` directories, `test.py` needs to be aware of the target and toolchain in use. This PR passes the `-t` and `-m` options to `test.py` when the `--compile-list` option is specified.

I will make a corresponding PR to mbedmicro/mbed that takes advantage of these options, but this patch to mbed-cli must be made first (since `test.py` will now require `-m` and `-t` to be present).

**Edit:** The corresponding PR on mbedmicro/mbed is located here: https://github.com/mbedmicro/mbed/pull/2244
