### PR TITLE
mbed CLI 0.9.x fixes and minor enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ mbed CLI is supported on Windows, Linux and Mac OS X. We're keen to learn about 
 
 ### Requirements
 
-* **Python** - mbed CLI is a Python script, so you'll need Python in order to use it. mbed CLI was tested with [version 2.7 of Python](https://www.python.org/download/releases/2.7/).
+* **Python** - mbed CLI is a Python script, so you'll need Python in order to use it. mbed CLI was tested with [version 2.7.9 of Python](https://www.python.org/download/releases/2.7/).
 
 * **Git and Mercurial** - mbed CLI supports both Git and Mercurial repositories, so you'll need to install both:
     * [Git](https://git-scm.com/).

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1570,11 +1570,15 @@ def new(name, scm='git', program=False, library=False, mbedlib=False, create_onl
         p.set_root()
         if not create_only and not p.get_os_dir() and not p.get_mbedlib_dir():
             url = mbed_lib_url if mbedlib else mbed_os_url
+            d = 'mbed' if mbedlib else 'mbed-os'
             try:
                 with cd(d_path):
                     add(url, depth=depth, protocol=protocol, top=False)
+                    if not mbedlib:
+                        with cd(d):
+                            repo = Repo.fromrepo()
+                            repo.checkout('latest')
             except Exception as e:
-                d = 'mbed' if mbedlib else 'mbed-os'
                 if os.path.isdir(os.path.join(d_path, d)):
                     rmtree_readonly(os.path.join(d_path, d))
                 raise e

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2157,7 +2157,7 @@ def test_(toolchain=None, target=None, compile_list=False, run_list=False, compi
 
 # Export command
 @subcommand('export',
-    dict(name=['-i', '--ide'], help='IDE to create project files for. Example: UVISION4, UVISION5, GCC_ARM, IAR, COIDE', required=True),
+    dict(name=['-i', '--ide'], help='IDE to create project files for. Example: UVISION4, UVISION5, GCC_ARM, IAR, COIDE'),
     dict(name=['-m', '--target'], help='Export for target MCU. Example: K64F, NUCLEO_F401RE, NRF51822...'),
     dict(name='--source', action='append', help='Source directory. Default: . (current dir)'),
     dict(name=['-c', '--clean'], action='store_true', help='Clean the build directory before compiling'),
@@ -2194,7 +2194,7 @@ def export(ide=None, target=None, source=False, clean=False, supported=False):
 
     popen(['python', '-u', os.path.join(tools_dir, 'project.py')]
           + list(chain.from_iterable(izip(repeat('-D'), macros)))
-          + ['-i', ide.lower(), '-m', target]
+          + (['-i', ide.lower(), '-m', target] if ide else [])
           + (['-c'] if clean else [])
           + list(chain.from_iterable(izip(repeat('--source'), source)))
           + args,

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -35,7 +35,7 @@ import argparse
 
 
 # Application version
-ver = '0.9.1'
+ver = '0.9.5'
 
 # Default paths to Mercurial and Git
 hg_cmd = 'hg'

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -449,7 +449,7 @@ class Hg(object):
                 lines = f.read().splitlines()
                 if tagpaths in lines:
                     idx = lines.index(tagpaths)
-                    m = re.match(r'^([\w_]+)\s*=\s*(.*)?$', lines[idx+1])
+                    m = re.match(r'^([\w_]+)\s*=\s*(.*)$', lines[idx+1])
                     if m:
                         if m.group(1) == 'default':
                             default_url = m.group(2)
@@ -1366,7 +1366,7 @@ class Cfg(object):
             lines = []
 
         for line in lines:
-            m = re.match(r'^([\w+-]+)\=(.*)?$', line)
+            m = re.match(r'^([\w+-]+)\=(.*)$', line)
             if m and m.group(1) == var:
                 lines.remove(line)
 
@@ -1390,7 +1390,7 @@ class Cfg(object):
             lines = []
 
         for line in lines:
-            m = re.match(r'^([\w+-]+)\=(.*)?$', line)
+            m = re.match(r'^([\w+-]+)\=(.*)$', line)
             if m and m.group(1) == var:
                 return m.group(2)
         return default_val
@@ -1406,7 +1406,7 @@ class Cfg(object):
 
         vars = {}
         for line in lines:
-            m = re.match(r'^([\w+-]+)\=(.*)?$', line)
+            m = re.match(r'^([\w+-]+)\=(.*)$', line)
             if m and m.group(1) and m.group(1) != 'ROOT':
                 vars[m.group(1)] = m.group(2)
         return vars

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2335,6 +2335,11 @@ def main():
 
     # Help messages adapt based on current dir
     cwd_root = os.getcwd()
+ 
+    if sys.version_info[0] != 2 or sys.version_info[1] < 7:
+        error(
+            "mbed CLI is compatible with Python version >= 2.7 and < 3.0\n"
+            "Please refer to the online guide available at https://github.com/ARMmbed/mbed-cli")
 
     # Parse/run command
     if len(sys.argv) <= 1:

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1291,9 +1291,7 @@ class Program(object):
             os.mkdir(path)
         with cd(path):
             tools_dir = 'tools'
-            if not os.path.exists(tools_dir):
-                return self.add_tools(path)
-            else:
+            if os.path.exists(tools_dir):
                 with cd(tools_dir):
                     try:
                         action("Updating the mbed 2.0 SDK tools...")

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LICENSE = open('LICENSE').read()
 
 setup(
     name="mbed-cli",
-    version="0.9.1",
+    version="0.9.5",
     description="ARM mbed command line tool for repositories version control, publishing and updating code from remotely hosted repositories (GitHub, GitLab and mbed.org), and invoking mbed OS own build system and export functions, among other operations",
     long_description=LONG_DESC,
     url='http://github.com/ARMmbed/mbed-cli',


### PR DESCRIPTION
This PR introduces

**Fixes:** 
* Fixed Python 2.7.3 backwards compatible regexes (#325)
* Fixed documentation to specify Python patch version that mbed CLI was tested with (#325)
* `mbed export -S/--supported` should not require -i/--ide (#326)


**Enhancements:**
* Add Python version detection and report error when using incompatible version (#325)
* `mbed update` will update the tools in mbed 2.0/Classic programs (#331)
* `mbed new` will checkout the latest mbed-os release marked with tag `latest` (#330)
* Bump version to 0.9.5