### PR TITLE
Fixing test name again for CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ test:
         - cd .tests && mbed new new-test
         - cd .tests/new-test && mbed ls
         - cd .tests/new-test && mbed compile --source=. --source=mbed-os/TESTS/integration/basic -j 0
-        - cd .tests/new-test && mbed test --compile -n tests-integration-basic -j 0
+        - cd .tests/new-test && mbed test --compile -n mbed-os-tests-integration-basic -j 0
         - cd .tests && mbed import https://developer.mbed.org/teams/Morpheus/code/mbed-Client-Morpheus-hg hg-test
         - cd .tests/hg-test && mbed update b02527cafcde8612ff051fea57e9975aca598807 --clean
         - cd .tests/hg-test && mbed update --clean


### PR DESCRIPTION
I got the test name wrong in my last PR https://github.com/ARMmbed/mbed-cli/pull/349, this should fix it once and for all.

Please hold off on merging until I get a chance to look at the CI logs.