### PR TITLE
Caching feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ Here is a list of currently implemented configuration settings:
  * `ARM_PATH`, `GCC_ARM_PATH`, `IAR_PATH` - defines the default path to ARM Compiler, GCC ARM and IAR Workbench toolchains. Default: none.
  * `protocol` - defines the default protocol used for importing or cloning of programs and libraries. The possible values are `https`, `http` and `ssh`. Use `ssh` if you have generated and registered SSH keys (Public Key Authentication) with a service like GitHub, GitLab, Bitbucket, etc. Read more about SSH keys [here](https://help.github.com/articles/generating-an-ssh-key/) Default: `https`.
  * `depth` - defines the *clone* depth for importing or cloning and applies only to *Git* repositories. Note that while this option may improve cloning speed, it may also prevent you from correctly checking out a dependency tree when the reference revision hash is older than the clone depth. Read more about shallow clones [here](https://git-scm.com/docs/git-clone). Default: none.
- * `cache` - defines the local path that will be used to store minimalistic copies of the imported or cloned repositories, and attempts to use them to minimize traffic and speed up future importing. Will disable caching if set to "off" or "none". Default: system temp path.
+ * `cache` - defines the local path that will be used to store minimalistic copies of the imported or cloned repositories, and attempts to use it to minimize traffic and speed up future imports of the same repositories. Use `on` or `enabled` to turn on caching in the system temp path. Default: none (disabled).
  
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -781,8 +781,7 @@ Here is a list of currently implemented configuration settings:
  * `ARM_PATH`, `GCC_ARM_PATH`, `IAR_PATH` - defines the default path to ARM Compiler, GCC ARM and IAR Workbench toolchains. Default: none.
  * `protocol` - defines the default protocol used for importing or cloning of programs and libraries. The possible values are `https`, `http` and `ssh`. Use `ssh` if you have generated and registered SSH keys (Public Key Authentication) with a service like GitHub, GitLab, Bitbucket, etc. Read more about SSH keys [here](https://help.github.com/articles/generating-an-ssh-key/) Default: `https`.
  * `depth` - defines the *clone* depth for importing or cloning and applies only to *Git* repositories. Note that while this option may improve cloning speed, it may also prevent you from correctly checking out a dependency tree when the reference revision hash is older than the clone depth. Read more about shallow clones [here](https://git-scm.com/docs/git-clone). Default: none.
- * `cache` - defines the local path that will be used to store minimalistic copies of the imported or cloned repositories, and attempts to use them to minimize traffic and speed up future importing. Default: none (system temp path).
- * `cache_disabled` - disables the caching functionality. Default: none.
+ * `cache` - defines the local path that will be used to store minimalistic copies of the imported or cloned repositories, and attempts to use them to minimize traffic and speed up future importing. Will disable caching if set to "off" or "none". Default: system temp path.
  
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -781,7 +781,8 @@ Here is a list of currently implemented configuration settings:
  * `ARM_PATH`, `GCC_ARM_PATH`, `IAR_PATH` - defines the default path to ARM Compiler, GCC ARM and IAR Workbench toolchains. Default: none.
  * `protocol` - defines the default protocol used for importing or cloning of programs and libraries. The possible values are `https`, `http` and `ssh`. Use `ssh` if you have generated and registered SSH keys (Public Key Authentication) with a service like GitHub, GitLab, Bitbucket, etc. Read more about SSH keys [here](https://help.github.com/articles/generating-an-ssh-key/) Default: `https`.
  * `depth` - defines the *clone* depth for importing or cloning and applies only to *Git* repositories. Note that while this option may improve cloning speed, it may also prevent you from correctly checking out a dependency tree when the reference revision hash is older than the clone depth. Read more about shallow clones [here](https://git-scm.com/docs/git-clone). Default: none.
- * `cache` (EXPERIMENTAL) - defines the local path that will be used to store minimalistic copies of the imported or cloned repositories, and attempts to use them to minimize traffic and speed up future importing. This feature is still under development, so this should not be used within a production environment. Default: none (disabled).
+ * `cache` - defines the local path that will be used to store minimalistic copies of the imported or cloned repositories, and attempts to use them to minimize traffic and speed up future importing. Default: none (system temp path).
+ * `cache_disabled` - disables the caching functionality. Default: none.
  
 ## Troubleshooting
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -849,9 +849,10 @@ class Repo(object):
         else:
             error('Invalid repository (%s)' % url.strip(), -1)
 
-        g = Global()
-        if cache_repositories and not g.get_cfg('CACHE_DISABLED'):
-            repo.cache = g.get_cfg('CACHE') or os.path.join(tempfile.gettempdir(), 'mbed-repo-cache')
+        cache_cfg = Global().get_cfg('CACHE', '')
+        if cache_repositories and cache_cfg != 'none' and cache_cfg != 'off' and cache_cfg != 'disabled':
+            loc = cache_cfg if (cache_cfg and cache_cfg != 'on' and cache_cfg != 'enabled') else None
+            repo.cache = loc or os.path.join(tempfile.gettempdir(), 'mbed-repo-cache')
 
         return repo
 
@@ -883,9 +884,10 @@ class Repo(object):
         repo.path = os.path.abspath(path)
         repo.name = os.path.basename(repo.path)
         
-        g = Global()
-        if cache_repositories and not g.get_cfg('CACHE_DISABLED'):
-            repo.cache = g.get_cfg('CACHE') or os.path.join(tempfile.gettempdir(), 'mbed-repo-cache')
+        cache_cfg = Global().get_cfg('CACHE', '')
+        if cache_repositories and cache_cfg != 'none' and cache_cfg != 'off' and cache_cfg != 'disabled':
+            loc = cache_cfg if (cache_cfg and cache_cfg != 'on' and cache_cfg != 'enabled') else None
+            repo.cache = loc or os.path.join(tempfile.gettempdir(), 'mbed-repo-cache')
 
         repo.sync()
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -850,7 +850,7 @@ class Repo(object):
             error('Invalid repository (%s)' % url.strip(), -1)
 
         cache_cfg = Global().get_cfg('CACHE', '')
-        if cache_repositories and cache_cfg != 'none' and cache_cfg != 'off' and cache_cfg != 'disabled':
+        if cache_repositories and cache_cfg and cache_cfg != 'none' and cache_cfg != 'off' and cache_cfg != 'disabled':
             loc = cache_cfg if (cache_cfg and cache_cfg != 'on' and cache_cfg != 'enabled') else None
             repo.cache = loc or os.path.join(tempfile.gettempdir(), 'mbed-repo-cache')
 
@@ -885,7 +885,7 @@ class Repo(object):
         repo.name = os.path.basename(repo.path)
         
         cache_cfg = Global().get_cfg('CACHE', '')
-        if cache_repositories and cache_cfg != 'none' and cache_cfg != 'off' and cache_cfg != 'disabled':
+        if cache_repositories and cache_cfg and cache_cfg != 'none' and cache_cfg != 'off' and cache_cfg != 'disabled':
             loc = cache_cfg if (cache_cfg and cache_cfg != 'on' and cache_cfg != 'enabled') else None
             repo.cache = loc or os.path.join(tempfile.gettempdir(), 'mbed-repo-cache')
 
@@ -1203,7 +1203,7 @@ class Program(object):
         if self.is_cwd and print_warning:
             warning(
                 "Could not find mbed program in current path \"%s\".\n"
-                "You can fix this by calling \"mbed new .\" or \"mbed config root .\" in the root of your program." % self.path)
+                "You can fix this by calling \"mbed new .\" in the root of your program." % self.path)
 
     def get_cfg(self, *args, **kwargs):
         return Cfg(self.path).get(*args, **kwargs) or Global().get_cfg(*args, **kwargs)
@@ -2379,6 +2379,10 @@ def config_(var=None, value=None, global_cfg=False, unset=False, list_config=Fal
         else:
             # Find the root of the program
             program = Program(os.getcwd())
+            if program.is_cwd:
+                error(
+                    "Could not find mbed program in current path \"%s\".\n"
+                    "Change the current directory to a valid mbed program or use the '--global' option to set global configuration." % program.path)
             with cd(program.path):
                 if unset:
                     program.set_cfg(var, None)

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -36,7 +36,7 @@ import tempfile
 
 
 # Application version
-ver = '0.9.10'
+ver = '1.0.0'
 
 # Default paths to Mercurial and Git
 hg_cmd = 'hg'

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1303,18 +1303,15 @@ class Program(object):
                     error("An error occurred while cloning the mbed SDK tools from \"%s\"" % mbed_sdk_tools_url)
 
     def update_tools(self, path):
-        if not os.path.exists(path):
-            os.mkdir(path)
-        with cd(path):
-            tools_dir = 'tools'
-            if os.path.exists(tools_dir):
-                with cd(tools_dir):
-                    try:
-                        action("Updating the mbed 2.0 SDK tools...")
-                        repo = Repo.fromrepo()
-                        repo.update()
-                    except Exception:
-                        error("An error occurred while update the mbed SDK tools from \"%s\"" % mbed_sdk_tools_url)
+        tools_dir = 'tools'
+        if os.path.exists(os.path.join(path, tools_dir)):
+            with cd(os.path.join(path, tools_dir)):
+                try:
+                    action("Updating the mbed 2.0 SDK tools...")
+                    repo = Repo.fromrepo()
+                    repo.update()
+                except Exception:
+                    error("An error occurred while update the mbed SDK tools from \"%s\"" % mbed_sdk_tools_url)
 
     def get_tools(self):
         mbed_tools_path = self.get_tools_dir()
@@ -1358,6 +1355,7 @@ class Program(object):
             with open('MACROS.txt') as f:
                 macros = f.read().splitlines()
         return macros
+
 
     def ignore_build_dir(self):
         build_path = os.path.join(self.path, self.build_dir)

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -291,7 +291,7 @@ class Bld(object):
         try:
             if not os.path.exists(rev_file):
                 action("Downloading library build \"%s\" (might take a minute)" % rev)
-                outfd = open(tmp_file, 'wb')
+                outfd = open(rev_file, 'wb')
                 inurl = urllib2.urlopen(url)
                 outfd.write(inurl.read())
                 outfd.close()
@@ -849,8 +849,9 @@ class Repo(object):
         else:
             error('Invalid repository (%s)' % url.strip(), -1)
 
-        if cache_repositories:
-            repo.cache = Program(repo.path).get_cfg('CACHE') or os.path.join(tempfile.gettempdir(), 'mbed-repo-cache')
+        g = Global()
+        if cache_repositories and not g.get_cfg('CACHE_DISABLED'):
+            repo.cache = g.get_cfg('CACHE') or os.path.join(tempfile.gettempdir(), 'mbed-repo-cache')
 
         return repo
 
@@ -881,8 +882,10 @@ class Repo(object):
 
         repo.path = os.path.abspath(path)
         repo.name = os.path.basename(repo.path)
-        if cache_repositories:
-            repo.cache = Program(repo.path).get_cfg('CACHE') or os.path.join(tempfile.gettempdir(), 'mbed-repo-cache')
+        
+        g = Global()
+        if cache_repositories and not g.get_cfg('CACHE_DISABLED'):
+            repo.cache = g.get_cfg('CACHE') or os.path.join(tempfile.gettempdir(), 'mbed-repo-cache')
 
         repo.sync()
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1442,6 +1442,9 @@ class Cfg(object):
 
     # Sets config value
     def set(self, var, val):
+        if not re.match(r'^([\w+-]+)$', var):
+            error("%s is invalid config variable name" % var)
+
         fl = os.path.join(self.path, self.file)
         try:
             with open(fl) as f:

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -265,6 +265,15 @@ class Bld(object):
         if not os.path.exists(path):
             os.mkdir(path)
 
+    def cleanup():
+        info("Cleaning up library build folder")
+        for fl in os.listdir('.'):
+            if not fl.startswith('.'):
+                if os.path.isfile(fl):
+                    os.remove(fl)
+                else:
+                    shutil.rmtree(fl)
+
     def clone(url, path=None, depth=None, protocol=None):
         m = Bld.isurl(url)
         if not m:
@@ -276,15 +285,6 @@ class Bld(object):
                 Bld.seturl(url+'/tip')
         except Exception as e:
             error(e[1], e[0])
-
-    def cleanup():
-        info("Cleaning up library build folder")
-        for fl in os.listdir('.'):
-            if not fl.startswith('.'):
-                if os.path.isfile(fl):
-                    os.remove(fl)
-                else:
-                    shutil.rmtree(fl)
 
     def fetch_rev(url, rev):
         rev_file = os.path.join('.'+Bld.name, '.rev-' + rev + '.zip')
@@ -383,6 +383,9 @@ class Hg(object):
 
     def init(path=None):
         popen([hg_cmd, 'init'] + ([path] if path else []) + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+
+    def cleanup():
+        return True
 
     def clone(url, name=None, depth=None, protocol=None):
         popen([hg_cmd, 'clone', formaturl(url, protocol), name] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
@@ -580,6 +583,11 @@ class Git(object):
 
     def init(path=None):
         popen([git_cmd, 'init'] + ([path] if path else []) + ([] if very_verbose else ['-q']))
+
+    def cleanup():
+        info("Cleaning up Git index")
+        if os.path.exists(os.path.join('.git', 'logs')):
+            rmtree_readonly(os.path.join('.git', 'logs'))
 
     def clone(url, name=None, depth=None, protocol=None):
         popen([git_cmd, 'clone', formaturl(url, protocol), name] + (['--depth', depth] if depth else []) + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
@@ -1046,6 +1054,7 @@ class Repo(object):
 
                     with cd(path):
                         scm.seturl(formaturl(url, protocol))
+                        scm.cleanup()
                         info("Update cached copy from remote repository")
                         scm.update(rev, True)
                         main = False

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LICENSE = open('LICENSE').read()
 
 setup(
     name="mbed-cli",
-    version="0.9.10",
+    version="1.0.0",
     description="ARM mbed command line tool for repositories version control, publishing and updating code from remotely hosted repositories (GitHub, GitLab and mbed.org), and invoking mbed OS own build system and export functions, among other operations",
     long_description=LONG_DESC,
     url='http://github.com/ARMmbed/mbed-cli',


### PR DESCRIPTION
This PR re-introduces repository caching as official/default mbed CLI feature:
- caching is enabled by default and uses the system/user default temp dir
- a user can override the cache location via the `CACHE` config setting
- a user can disable caching by setting up the `CACHE_DISABLED` config variable
- improved handling of mbed library builds (.bld/mbed 2.0)

Also fixes how cached repositories are handling across different protocols (e.g. cached ssh repo is cloned as https repo)

Reviewers:
- [ ] @sg- 
- [ ] @theotherjimmy 

Also cc @bridadan as this might have implications with the CI
