### PR TITLE
Use 'urllib2' for retrieving mbed library

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -29,7 +29,7 @@ import stat
 import errno
 from itertools import chain, izip, repeat
 from urlparse import urlparse
-import urllib
+import urllib2
 import zipfile
 import argparse
 
@@ -281,7 +281,10 @@ class Bld(object):
         try:
             if not os.path.exists(tmp_file):
                 action("Downloading mbed library build \"%s\" (might take a minute)" % rev)
-                urllib.urlretrieve(url, tmp_file)
+                outfd = open(tmp_file, 'wb')
+                inurl = urllib2.urlopen(url)
+                outfd.write(inurl.read())
+                outfd.close()
         except:
             if os.path.isfile(tmp_file):
                 os.remove(tmp_file)


### PR DESCRIPTION
For some reason when using `urllib` in my environment (which includes a Zscaler network proxy) `urllib.urlretrieve()` does not work ending up with an error message _"301 Moved Permanently"_.
Python library `urllib2` doesn't have this issue but does not provide method `urlretrieve()`, so a little workaround is required.