### PR TITLE
mbed CLI 0.9.10 fixes

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1245,7 +1245,6 @@ class Program(object):
                         missing = []
                     except ProcessException:
                         warning("Unable to auto-install required Python modules.")
-                        pass
 
         except (IOError, ImportError, OSError):
             pass
@@ -1385,7 +1384,7 @@ class Global(object):
     def list_cfg(self, *args, **kwargs):
         return Cfg(self.path).list(*args, **kwargs)
 
-# Cfg classed used for handling the config backend 
+# Cfg classed used for handling the config backend
 class Cfg(object):
     path = None
     file = ".mbed"
@@ -1415,7 +1414,6 @@ class Cfg(object):
                 f.write('\n'.join(lines) + '\n')
         except (IOError, OSError):
             warning("Unable to write config file %s" % fl)
-            pass
 
     # Gets config value
     def get(self, var, default_val=None):
@@ -1797,7 +1795,7 @@ def publish(all_refs=None, msg=None, top=True):
             repo.publish(all_refs)
         else:
             if top:
-                action("Nothing to publish to the remote repository (the source tree is unmodified)")            
+                action("Nothing to publish to the remote repository (the source tree is unmodified)")
     except ProcessException as e:
         if e[0] != 1:
             raise e
@@ -1987,7 +1985,7 @@ def sync(recursive=True, keep_refs=False, top=True):
 def list_(detailed=False, prefix='', p_path=None, ignore=False):
     repo = Repo.fromrepo()
 
-    print("%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url+('#'+str(repo.rev)[:12] if repo.rev else '') if detailed else str(repo.rev)[:12]) or 'no revision')))
+    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url+('#'+str(repo.rev)[:12] if repo.rev else '') if detailed else str(repo.rev)[:12]) or 'no revision'))
 
     for i, lib in enumerate(sorted(repo.libs, key=lambda l: l.path)):
         if prefix:
@@ -2157,7 +2155,6 @@ def test_(toolchain=None, target=None, compile_list=False, run_list=False, compi
         if not build:
             build = os.path.join(program.path, program.build_dir, 'tests', target, tchain)
 
-        
         if test_spec:
             # Preserve path to given test spec
             test_spec = os.path.relpath(os.path.join(orig_path, test_spec), program.path)
@@ -2297,7 +2294,7 @@ def detect():
 def config_(var=None, value=None, global_cfg=False, unset=False, list_config=False):
     name = var
     var = str(var).upper()
-    
+
     if list_config:
         g = Global()
         g_vars = g.list_cfg().items()
@@ -2306,7 +2303,7 @@ def config_(var=None, value=None, global_cfg=False, unset=False, list_config=Fal
             for v in g_vars:
                 log("%s=%s\n" % (v[0], v[1]))
         else:
-            log("No global configuration is set\n")        
+            log("No global configuration is set\n")
         log("\n")
 
         p = Program(os.getcwd())
@@ -2389,7 +2386,7 @@ def main():
 
     # Help messages adapt based on current dir
     cwd_root = os.getcwd()
- 
+
     if sys.version_info[0] != 2 or sys.version_info[1] < 7:
         error(
             "mbed CLI is compatible with Python version >= 2.7 and < 3.0\n"

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -819,13 +819,16 @@ class Repo(object):
     def fromlib(cls, lib=None):
         with open(lib) as f:
             ref = f.read(200)
-            if ref.startswith('!<arch>'):
-                warning(
-                    "A static library \"%s\" in \"%s\" uses a non-standard .lib file extension, which is not compatible with the mbed build tools.\n"
-                    "Please change the extension of \"%s\" (for example to \"%s\").\n" % (os.path.basename(lib), os.path.split(lib)[0], os.path.basename(lib), os.path.basename(lib).replace('.lib', '.ar')))
-                return False
-            else:
-                return cls.fromurl(ref, lib[:-4])
+
+        m_local = re.match(regex_local_ref, ref.strip().replace('\\', '/'))
+        m_repo_url = re.match(regex_url_ref, ref.strip().replace('\\', '/'))
+        m_bld_url = re.match(regex_build_url, ref.strip().replace('\\', '/'))
+        if not (m_local or m_bld_url or m_repo_url):
+            warning(
+                "File \"%s\" in \"%s\" uses a non-standard .lib file extension, which is not compatible with the mbed build tools.\n" % (os.path.basename(lib), os.path.split(lib)[0]))
+            return False
+        else:
+            return cls.fromurl(ref, lib[:-4])
 
     @classmethod
     def fromrepo(cls, path=None):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LICENSE = open('LICENSE').read()
 
 setup(
     name="mbed-cli",
-    version="0.9.9",
+    version="0.9.10",
     description="ARM mbed command line tool for repositories version control, publishing and updating code from remotely hosted repositories (GitHub, GitLab and mbed.org), and invoking mbed OS own build system and export functions, among other operations",
     long_description=LONG_DESC,
     url='http://github.com/ARMmbed/mbed-cli',


### PR DESCRIPTION
Fixed:
* Git re-association with tip of a branch matching the checkout hash, where local and remote branches were treated as same entity (and they might be different if the user hasn't merged with the latest origin/branch). As reported ARMmbed/mbed-os#3037
* Handling of arbitrary .lib files
* Pylint fixes (9.9/10)

Reviewers:
- [x] Review by @SeppoTakalo 
- [x] Review by @sg-