### PR TITLE
Target awareness, part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Image: BUILD/K64F/GCC_ARM/mbed-os-program.bin
 
 The arguments for *compile* are:
 
-* `-m <MCU>` to select a target.
+* `-m <MCU>` to select a target. If 'detect' or 'auto' parameter is passed then mbed CLI will attempt to detect the connected target and compile against it.
 * `-t <TOOLCHAIN>` to select a toolchain (of those defined in `mbed_settings.py`, see above). The value can be either `ARM` (ARM Compiler 5), `GCC_ARM` (GNU ARM Embedded), or `IAR` (IAR Embedded Workbench for ARM).
 * `--source <SOURCE>` to select the source directory. The default is `.` (the current directorty). You can specify multiple source locations, even outside the program tree.
 * `--build <BUILD>` to select the build directory. Default: `BUILD/` inside your program.
@@ -443,6 +443,8 @@ $ mbed compile -t GCC_ARM -m K64F --profile mbed-os/tools/profiles/debug.json
 
 Using `mbed target <target>` and `mbed toolchain <toolchain>` you can set the default target and toolchain for your program, meaning you won't have to specify these every time you compile or generate IDE project files.
 
+You can also use `mbed target detect', which will attempt to detect the connected target board and use it as parameter every time you compile or export.
+
 
 ## Exporting to desktop IDEs
 
@@ -501,7 +503,7 @@ mbedgt: completed in 21.28 sec
 ```
 
 The arguments to `test` are:
-* `-m <MCU>` to select a target for the compilation.
+* `-m <MCU>` to select a target for the compilation. If 'detect' or 'auto' parameter is passed then mbed CLI will attempt to detect the connected target and compile against it.
 * `-t <TOOLCHAIN>` to select a toolchain (of those defined in `mbed_settings.py`, see above), where `toolchain` can be either `ARM` (ARM Compiler 5), `GCC_ARM` (GNU ARM Embedded), or `IAR` (IAR Embedded Workbench for ARM).
 * `--compile-list` to list all the tests that can be built
 * `--run-list` to list all the tests that can be ran (they must be built first)

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1329,11 +1329,11 @@ class Program(object):
         if target and (target.lower() == 'detect' or target.lower() == 'auto'):
             targets = self.get_detected_targets()
             if targets == False:
-                error("The target detection requires that the 'mbed-ls' python module is installed.")
+                error("The target detection requires that the 'mbed-ls' python module is installed.\nYou can install mbed-ls by running 'pip install mbed-ls'.")
             elif len(targets) > 1:
                 error("Multiple targets were detected.\nOnly 1 target board should be connected to your system when you use the '-m auto' switch.")
             elif len(targets) == 0:
-                error("No targets were detected.\nPlease make sure a target board to this system.")
+                error("No targets were detected.\nPlease make sure a target board is connected to this system.")
             else:
                 action("Detected \"%s\" connected to \"%s\" and using com port \"%s\"" % (targets[0]['name'], targets[0]['mount'], targets[0]['serial']))
                 target = targets[0]['name']

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1323,20 +1323,21 @@ class Program(object):
         return env
 
     def get_target(self, target=None):
-        if target:
-            if target.lower() == 'detect' or target.lower() == 'auto':
-                targets = self.get_detected_targets()
-                if targets == False:
-                    error("The target detection requires that the 'mbed-ls' python module is installed.")
-                elif len(targets) > 1:
-                    error("Multiple targets were detected.\nOnly 1 target board should be connected to your system when you use the '-m auto' switch.")
-                elif len(targets) == 0:
-                    error("No targets were detected.\nPlease make sure a target board to this system.")
-                else:
-                    action("Detected \"%s\" connected to \"%s\" and using com port \"%s\"" % (targets[0]['name'], targets[0]['mount'], targets[0]['serial']))
-                    target = targets[0]['name']
-        else:
-            target = self.get_cfg('TARGET')
+        target_cfg = self.get_cfg('TARGET')
+        target = target if target else target_cfg
+
+        if target and (target.lower() == 'detect' or target.lower() == 'auto'):
+            targets = self.get_detected_targets()
+            if targets == False:
+                error("The target detection requires that the 'mbed-ls' python module is installed.")
+            elif len(targets) > 1:
+                error("Multiple targets were detected.\nOnly 1 target board should be connected to your system when you use the '-m auto' switch.")
+            elif len(targets) == 0:
+                error("No targets were detected.\nPlease make sure a target board to this system.")
+            else:
+                action("Detected \"%s\" connected to \"%s\" and using com port \"%s\"" % (targets[0]['name'], targets[0]['mount'], targets[0]['serial']))
+                target = targets[0]['name']
+
         if target is None:
             error("Please specify target using the -m switch or set default target using command 'mbed target'", 1)
         return target


### PR DESCRIPTION
Add initial support for target awareness in mbed CLI:
* `mbed compile -t TOOLCHAIN -m detect` or `mbed compile -t TOOLCHAIN -m auto` will compile for the detected connected target.
* `mbed detect` will provide (limited) report for connected targets even executed outside mbed program or mbed-os codebase.
* `mbed target detect` will set config option to detect the connected target as default behavior

Various checks are added:
* multiple connected targets
* no connected targets
* no mbed-ls support

Reviewers:
- [x] Review by @theotherjimmy 
- [x] Review by @bridadan 
- [x] Review by @sg-