### PR TITLE
Allowing root directory configuration

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2434,10 +2434,10 @@ def config_(var=None, value=None, global_cfg=False, unset=False, list_config=Fal
         else:
             # Find the root of the program
             program = Program(os.getcwd())
-            if program.is_cwd:
+            if program.is_cwd and not var == 'ROOT':
                 error(
                     "Could not find mbed program in current path \"%s\".\n"
-                    "Change the current directory to a valid mbed program or use the '--global' option to set global configuration." % program.path)
+                    "Change the current directory to a valid mbed program, set the current directory as an mbed program with 'mbed config root .', or use the '--global' option to set global configuration." % program.path)
             with cd(program.path):
                 if unset:
                     program.set_cfg(var, None)


### PR DESCRIPTION
As of 1.0.0, you can no longer set the root directory of program that doesn't already have a `.mbed` file, which kind of defeats the purpose of the option :)

This patch lets all local changes to the `ROOT` config option through the config check.

It also changes the error message printed for any other variable that is trying to be modified to include this way forward.

The error before was the following:
```
C:\Users\bridan01\Documents\dev\m_mbed\mbed>mbed target K64F
[mbed] ERROR: Could not find mbed program in current path "C:\Users\bridan01\Documents\dev\m_mbed\mbed".
[mbed] ERROR: Change the current directory to a valid mbed program or use the '--global' option to set global configuration.
```

Now it is the following:
```
C:\Users\bridan01\Documents\dev\m_mbed\mbed>mbed target K64F
[mbed] ERROR: Could not find mbed program in current path "C:\Users\bridan01\Documents\dev\m_mbed\mbed".
[mbed] ERROR: Change the current directory to a valid mbed program, set the current directory as an mbed program with 'mbed config root .', or use the '--global' option to set global configuration.
```

Please review @screamerbg 