### PR TITLE
Add define/macro of the main application commit/hash ID

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1433,6 +1433,10 @@ class Program(object):
         if os.path.isfile('MACROS.txt'):
             with open('MACROS.txt') as f:
                 macros = f.read().splitlines()
+        if os.path.isdir(self.path) and Repo.isrepo(self.path):
+            repo = Repo.fromrepo(self.path)
+            if repo and repo.rev:
+                macros.append('MBED_APP_COMMIT=\"'+repo.rev+'\"')
         return macros
 
 


### PR DESCRIPTION
Based on suggestion from @bremoran #439 

It is useful to know exactly which revision of firmware a device is running, particularly for examining bug reports. If mbed-cli provided a define for the application commit ID, that would make it easy for application developers to add this information to their traces.

This is targeting the mbed CLI 1.1 release.