### PR TITLE
Supported lists

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2383,7 +2383,7 @@ def test_(toolchain=None, target=None, compile_list=False, run_list=False, compi
     dict(name=['-m', '--target'], help='Export for target MCU. Example: K64F, NUCLEO_F401RE, NRF51822...'),
     dict(name='--source', action='append', help='Source directory. Default: . (current dir)'),
     dict(name=['-c', '--clean'], action='store_true', help='Clean the build directory before compiling'),
-    dict(name=['-S', '--supported'], dest='supported', action='store_true', help='Shows supported matrix of targets and toolchains'),
+    dict(name=['-S', '--supported'], dest='supported', const="matrix", choices=["matrix", "ides"], nargs="?", help='Shows supported matrix of targets and toolchains'),
     dict(name='--app-config', dest="app_config", help="Path of an app configuration file (Default is to look for 'mbed_app.json')"),
     help='Generate an IDE project',
     description=(
@@ -2404,8 +2404,8 @@ def export(ide=None, target=None, source=False, clean=False, supported=False, ap
     env = program.get_env()
 
     if supported:
-        popen([python_cmd, '-u', os.path.join(tools_dir, 'project.py')]
-              + (['-S'] if supported else []) + (['-v'] if very_verbose else []),
+        popen(['python', '-u', os.path.join(tools_dir, 'project.py')]
+              + (['-S', supported] if supported else []) + (['-v'] if very_verbose else []),
               env=env)
         return
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2169,7 +2169,7 @@ def status_(ignore=False):
     dict(name=['-c', '--clean'], action='store_true', help='Clean the build directory before compiling'),
     dict(name=['-f', '--flash'], action='store_true', help='Flash the built firmware onto a connected target.'),
     dict(name=['-N', '--artifact-name'], help='Name of the built program or library'),
-    dict(name=['-S', '--supported'], dest='supported', action='store_true', help='Shows supported matrix of targets and toolchains'),
+    dict(name=['-S', '--supported'], dest='supported', const="matrix", choices=["matrix", "toolchains", "targets"], nargs="?", help='Shows supported matrix of targets and toolchains'),
     dict(name='--app-config', dest="app_config", help="Path of an app configuration file (Default is to look for 'mbed_app.json')"),
     help='Compile code using the mbed build tools',
     description=("Compile this program using the mbed build tools."))
@@ -2192,8 +2192,8 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
         source = [os.path.relpath(program.path, orig_path)]
 
     if supported:
-        popen([python_cmd, '-u', os.path.join(tools_dir, 'make.py')]
-              + (['-S'] if supported else []) + (['-v'] if very_verbose else [])
+        popen(['python', '-u', os.path.join(tools_dir, 'make.py')]
+              + (['-S', supported] if supported else []) + (['-v'] if very_verbose else [])
               + (['--app-config', app_config] if app_config else [])
               + args,
               env=env)


### PR DESCRIPTION
Added ability to list toolchains, ides, targets in addition to the supported matrix output. Solves [#306](https://github.com/ARMmbed/mbed-cli/issues/306). 

NOTE: This depends on https://github.com/ARMmbed/mbed-os/pull/3993. @screamerbg @theotherjimmy can you guys think of a workaround? Should I just add a try catch?
```
   if supported:
        popen(['python', '-u', os.path.join(tools_dir, 'project.py')]
# The offending line
              + (['-S', supported] if supported else []) + (['-v'] if very_verbose else []),
              env=env)
        return
```