### PR TITLE
Fixed caching issue with local branches

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -254,6 +254,7 @@ def scm(name):
 @staticclass
 class Bld(object):
     name = 'bld'
+    def_branch = 'default'
 
     def isurl(url):
         m_url = re.match(regex_url_ref, url.strip().replace('\\', '/'))
@@ -373,6 +374,7 @@ class Bld(object):
 @staticclass
 class Hg(object):
     name = 'hg'
+    def_branch = 'default'
     ignore_file = os.path.join('.hg', 'hgignore')
 
     def isurl(url):
@@ -573,6 +575,7 @@ class Hg(object):
 @staticclass
 class Git(object):
     name = 'git'
+    def_branch = 'master'
     ignore_file = os.path.join('.git', 'info', 'exclude')
 
     def isurl(url):
@@ -1078,6 +1081,8 @@ class Repo(object):
                         scm.seturl(formaturl(url, protocol))
                         scm.cleanup()
                         info("Update cached copy from remote repository")
+                        if not rev:
+                            rev = scm.def_branch
                         scm.update(rev, True)
                         main = False
                 except (ProcessException, IOError):

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -254,7 +254,7 @@ def scm(name):
 @staticclass
 class Bld(object):
     name = 'bld'
-    def_branch = 'default'
+    default_branch = 'default'
 
     def isurl(url):
         m_url = re.match(regex_url_ref, url.strip().replace('\\', '/'))
@@ -374,7 +374,7 @@ class Bld(object):
 @staticclass
 class Hg(object):
     name = 'hg'
-    def_branch = 'default'
+    default_branch = 'default'
     ignore_file = os.path.join('.hg', 'hgignore')
 
     def isurl(url):
@@ -575,7 +575,7 @@ class Hg(object):
 @staticclass
 class Git(object):
     name = 'git'
-    def_branch = 'master'
+    default_branch = 'master'
     ignore_file = os.path.join('.git', 'info', 'exclude')
 
     def isurl(url):
@@ -1082,7 +1082,7 @@ class Repo(object):
                         scm.cleanup()
                         info("Update cached copy from remote repository")
                         if not rev:
-                            rev = scm.def_branch
+                            rev = scm.default_branch
                         scm.update(rev, True)
                         main = False
                 except (ProcessException, IOError):


### PR DESCRIPTION
Fixed a caching issue with mbed CLI where copied repository has remnants of local branches. It's expected that copied/cached repositories look exactly freshly cloned ones without caching