### PR TITLE
New Feature: Flash Target Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ The arguments for *compile* are:
 * `--library` to compile the code as a [static .a/.ar library](#compiling-static-libraries).
 * `--config` to inspect the runtime compile configuration (see below).
 * `-S` or `--supported` shows a matrix of the supported targets and toolchains.
+* `-f` or `--flash` to flash/program a connected target after successful compile.
 * `-c ` to build from scratch, a clean build or rebuild.
 * `-j <jobs>` to control the compile processes on your machine. The default value is 0, which infers the number of processes from the number of cores on your machine. You can use `-j 1` to trigger a sequential compile of source code.
 * `-v` or `--verbose` for verbose diagnostic output.

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2249,7 +2249,7 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
                     error("Unable to flash the target board connected to your system.", 1)
 
                 if not reset_dev(detected['port']):
-                    error("Unable to reset the target board connected to your system.", 1)
+                    error("Unable to reset the target board connected to your system.\nThis might be caused by an old interface firmware.\nPlease check the board page for new firmware.", 1)
 
     program.set_defaults(target=target, toolchain=tchain)
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2243,7 +2243,7 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
                 try:
                     from mbed_host_tests.host_tests_toolbox import flash_dev, reset_dev
                 except (IOError, ImportError, OSError):
-                    error("The target programing requires that the 'mbed-greentea' python module is installed.\nYou can install mbed-ls by running 'pip install mbed-greentea'.")
+                    error("The '-f' option requires that the 'mbed-greentea' python module is installed.\nYou can install mbed-ls by running 'pip install mbed-greentea'.")
                     return False
 
                 flash_dev(detected['msd'], fw_file, program_cycle_s=0)


### PR DESCRIPTION
Added feature support for -f/--flash to `mbed compile` to flash (and reset) connected target board after successful compile.

The implementation uses greentea/htrun framework and therefore relies on the same routines as testing.

To use:
```
$ mbed compile -t <toolchain> -m <mcu|DETECT> -f|--flash
```

Example output:
```
Total Static RAM memory (data + bss): 22732 bytes
Total RAM memory (data + bss + heap + stack): 22732 bytes
Total Flash memory (text + data + misc): 30266 bytes

Image: .\BUILD\NUCLEO_F429ZI\ARM\mbed-os-example-blinky.bin
[mbed] Detected "NUCLEO_F429ZI" connected to "E:" and using com port "COM6"
        1 file(s) copied.
```