### PR TITLE
Skip mbed-os import in subdirs

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1116,6 +1116,12 @@ class Repo(object):
 
             for f in files:
                 if f.endswith('.lib') or f.endswith('.bld'):
+                    # If we are in a subdirectory that is importing mbed-os,
+                    # skip the import of mbed-os: the app will have already
+                    # imported mbed-os.
+                    if (f == 'mbed-os.lib') and (root != cwd_root):
+                        action("Skipping redundant import of mbed-os in \"%s\"" % self.path)
+                        continue
                     repo = Repo.fromlib(os.path.join(root, f))
                     if repo:
                         yield repo

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1120,7 +1120,6 @@ class Repo(object):
                     # skip the import of mbed-os: the app will have already
                     # imported mbed-os.
                     if (f == 'mbed-os.lib') and (root != cwd_root):
-                        action("Skipping redundant import of mbed-os in \"%s\"" % self.path)
                         continue
                     repo = Repo.fromlib(os.path.join(root, f))
                     if repo:


### PR DESCRIPTION
The change is rather straightforward - if we come across an mbed-os.lib file in a library imported by an app, skip it. My test set up is as follows:

* A library that has an mbed-os.lib in it.
* An app that imports that library as well as mbed-os (e.g., has two *.lib files).

mbed import of both yields the desired results:

* Importing the library alone gets me an mbed-os to work with
* Importing the app gets me the library and mbed-os in the top level directory with no redundant mbed-os import

My knowledge of mbed-cli.py is limited, however, so the above may not be sufficient. Please review - I will not be at all offended by rejection.

Fixes #472 - mbed-cli can clone mbed-os.lib more than once.