### PR TITLE
Fix virtualenv --relocatable issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright (c) 2016 ARM Limited, All Rights Reserved
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
When setuptools creates console scripts during the install process to the host system and no shebang is defined in the setup.py, setuptools seems to hard code the current Python path as the shebang of the newly created script. This breaks the relocation feature in virtualenv. The issue is that when the virtualenv is moved to a new location the old absolute path in the console script shebang stays. By defining shebang in the setup.py, setuptools copies it to the console scripts it creates for the given module.