### PR TITLE
In the event your CWD has been removed this cleans up the error messa…

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2562,9 +2562,14 @@ def help_():
 
 def main():
     global verbose, very_verbose, remainder, cwd_root
+    status = -1
 
     # Help messages adapt based on current dir
-    cwd_root = os.getcwd()
+    try:
+        cwd_root = os.getcwd()
+    except Exception as e:
+        error("Unable to get current directory: %s" % e, status)
+    sys.exit(status or -1)
 
     if sys.version_info[0] != 2 or sys.version_info[1] < 7:
         error(


### PR DESCRIPTION
…ge while running mbed-cli.

Current error message:

Traceback (most recent call last):
  File "/usr/local/bin/mbed", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/mbed/mbed.py", line 2567, in main
    cwd_root = os.getcwd()
OSError: [Errno 2] No such file or directory

New error message:

[mbed] ERROR: Unable to get current directory: [Errno 2] No such file or directory
---