### PR TITLE
Note about ARMC5 installation 64-bit Linux & Spelling typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ The directories of Git and Mercurial executables (`git` and `hg`) need to be in 
     * Compilers: GCC ARM, ARM Compiler 5, IAR.
     * IDE: Keil uVision, DS-5, IAR Workbench.
 
+<span class="tips">**Note:** When installing the ARM Compiler 5 on a 64-bit Linux machine, you may need to also install the i386 architecture package:</span>
+
+```
+$ sudo dpkg --add-architecture i386
+$ sudo apt-get update
+$ sudo apt-get install libc6:i386 libncurses5:i386 libstdc++6:i386
+```
+
 ### Video tutorial for manual installation 
 
 <span class="images">[![Video tutorial](http://img.youtube.com/vi/cM0dFoTuU14/0.jpg)](https://www.youtube.com/watch?v=cM0dFoTuU14)</span>

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Edit `mbed_settings.py` to set your toolchain:
 
 * To use the [ARM Compiler toolchain](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler-5/downloads), set `ARM_PATH` to the *base* directory of your ARM Compiler installation (example: C:\Program Files\ARM\armcc5.06). The recommended version of the ARM Compiler toolchain is 5.06.
 * To use the [GCC ARM Embedded toolchain](https://launchpad.net/gcc-arm-embedded), set `GCC_ARM_PATH` to the *binary* directory of your GCC ARM installation (example: C:\Program Files\GNU Tools ARM Embedded\6 2017q2\bin). Use version 6 of GCC ARM Embedded; version 5.0 or any older version might be incompatible with the tools.
-* To use the [IAR EWARM toolchain](https://www.iar.com/iar-embedded-workbench/#!?architecture=ARM), set `IAR_PATH` to the *base* directory of your IAR installation. Use versions 7.80 of IAR EWARM; prior versions might be incompatible with the tools.
+* To use the [IAR EWARM toolchain](https://www.iar.com/iar-embedded-workbench/#!?architecture=ARM), set `IAR_PATH` to the *base* directory of your IAR installation (example: C:\Program Files (x86)\IAR Systems\Embedded Workbench 8.0\arm). Use versions 7.80 or higher of the IAR EWARM; prior versions might be incompatible with the tools.
 
 Because `mbed_settings.py` contains local settings (possibly relevant only to a single OS on a single machine), you should not check it into version control. 
 

--- a/README.md
+++ b/README.md
@@ -699,12 +699,12 @@ When you create a new (local) version control managed program or library, its re
 1. Copy the URL/location of the new repository in your clipboard. 
 1. Open command-line in the local repository directory (for example, change directory to `mbed-os-example/local-lib`).
 1. To associate the local repository:
- * For Git, run `git remote add origin <url-or-paht-to-your-remote-repo>`.
+ * For Git, run `git remote add origin <url-or-path-to-your-remote-repo>`.
  * For Mercurial, edit .hg/hgrc and add (or replace if exists):
  
             ```
             [paths]
-            default = <url-or-paht-to-your-remote-repo>
+            default = <url-or-path-to-your-remote-repo>
             ```
 
 1. Run `mbed publish` to publish your changes.
@@ -745,7 +745,7 @@ To update your program to another upstream version, go to the root folder of the
 $ mbed update [branch|tag|revision]
 ```
 
-This fetches new revisions from the remote repository, updating the program to the specified branch, tag or revision. If you don't specificy any of these, then `mbed update` updates to the latest revision of the current branch. `mbed update` performs this series of actions recursively against all dependencies in the program tree.
+This fetches new revisions from the remote repository, updating the program to the specified branch, tag or revision. If you don't specify any of these, then `mbed update` updates to the latest revision of the current branch. `mbed update` performs this series of actions recursively against all dependencies in the program tree.
 
 #### Updating a library
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Edit `mbed_settings.py` to set your toolchain:
 
 * To use the [ARM Compiler toolchain](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler-5/downloads), set `ARM_PATH` to the *base* directory of your ARM Compiler installation (example: C:\Program Files\ARM\armcc5.06). The recommended version of the ARM Compiler toolchain is 5.06.
 * To use the [GCC ARM Embedded toolchain](https://launchpad.net/gcc-arm-embedded), set `GCC_ARM_PATH` to the *binary* directory of your GCC ARM installation (example: C:\Program Files\GNU Tools ARM Embedded\6 2017q2\bin). Use version 6 of GCC ARM Embedded; version 5.0 or any older version might be incompatible with the tools.
-* To use the [IAR EWARM toolhain](https://www.iar.com/iar-embedded-workbench/#!?architecture=ARM), set `IAR_PATH` to the *base* directory of your IAR installation. Use versions 7.80 of IAR EWARM; prior versions might be incompatible with the tools.
+* To use the [IAR EWARM toolchain](https://www.iar.com/iar-embedded-workbench/#!?architecture=ARM), set `IAR_PATH` to the *base* directory of your IAR installation. Use versions 7.80 of IAR EWARM; prior versions might be incompatible with the tools.
 
 Because `mbed_settings.py` contains local settings (possibly relevant only to a single OS on a single machine), you should not check it into version control. 
 


### PR DESCRIPTION
On Linux, ARMC5 installation produces errors and internal faults on a 64-bit machine. This note adds clarification regarding the usage of a 32-bit executable on a 64-bit machine and commands to install the i386 architecture package.