### PR TITLE
Fix capitalization in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## Introduction
 
-mbed CLI is the name of the ARM mbed command-line tool, packaged as mbed-cli. mbed CLI enables Git- and Mercurial-based version control, dependencies management, code publishing, support for remotely hosted repositories (GitHub, GitLab and mbed.org), use of the ARM mbed OS build system and export functions and other operations.
+Arm Mbed CLI is the name of the Arm Mbed command-line tool, packaged as `mbed-cli`. Mbed CLI enables Git- and Mercurial-based version control, dependencies management, code publishing, support for remotely hosted repositories (GitHub, GitLab and mbed.org), use of the Arm Mbed OS build system and export functions and other operations.
 
-This document covers the installation and usage of mbed CLI.
+This document covers the installation and usage of Mbed CLI.
 
 ## Table of Contents
 
-1. [Using mbed CLI](#using-mbed-cli)
+1. [Using Mbed CLI](#using-mbed-cli)
 1. [Installing and uninstalling](#installing-mbed-cli)
 1. [Understanding working context and program root](#before-you-begin-understanding-the-working-context-and-program-root)
 1. [Creating and importing programs](#creating-and-importing-programs)
@@ -31,42 +31,42 @@ This document covers the installation and usage of mbed CLI.
 1. [Updating programs and libraries](#updating-programs-and-libraries)
     1. [Updating to an upstream version](#updating-to-an-upstream-version)
     2. [Update examples](#update-examples)
-1. [mbed CLI configuration](#mbed-cli-configuration)
+1. [Mbed CLI configuration](#mbed-cli-configuration)
 1. [Troubleshooting](#troubleshooting)
 
 
-## Using mbed CLI
+## Using Mbed CLI
 
-The basic workflow for mbed CLI is to:
+The basic workflow for Mbed CLI is to:
 
-1. Initialize a new repository, for either a new application (or library) or an imported one. In both cases, this action also adds the mbed OS codebase.
+1. Initialize a new repository, for either a new application (or library) or an imported one. In both cases, this action also adds the Mbed OS codebase.
 1. Build the application code.
 1. Test your build.
 1. Publish your application.
 
-To support long-term development, mbed CLI offers source control, including selective updates of libraries and the codebase, support for multiple toolchains and manual configuration of the system.
+To support long-term development, Mbed CLI offers source control, including selective updates of libraries and the codebase, support for multiple toolchains and manual configuration of the system.
 
-<span class="tips">**Tip:** To list all mbed CLI commands, use `mbed --help`. A detailed command-specific help is available by using `mbed <command> --help`.</span>
+<span class="tips">**Tip:** To list all Mbed CLI commands, use `mbed --help`. A detailed command-specific help is available by using `mbed <command> --help`.</span>
 
 ## Installation
 
-Windows, Linux and Mac OS X support mbed CLI. We're keen to learn about your experience with mbed CLI on other operating systems at the [mbed CLI development page](https://github.com/ARMmbed/mbed-cli).
+Windows, Linux and Mac OS X support Mbed CLI. We're keen to learn about your experience with Mbed CLI on other operating systems at the [Mbed CLI development page](https://github.com/ARMmbed/mbed-cli).
 
 ### Requirements
 
-* **Python** - mbed CLI is a Python script, so you'll need Python to use it. We test mbed CLI with [version 2.7.11 of Python](https://www.python.org/downloads/release/python-2711/). It is not compatible with Python 3.
+* **Python** - Mbed CLI is a Python script, so you'll need Python to use it. We test Mbed CLI with [version 2.7.11 of Python](https://www.python.org/downloads/release/python-2711/). It is not compatible with Python 3.
 
-* **Git and Mercurial** - mbed CLI supports both Git and Mercurial repositories, so you need to install both:
+* **Git and Mercurial** - Mbed CLI supports both Git and Mercurial repositories, so you need to install both:
     * [Git](https://git-scm.com/) - version 1.9.5 or later.
     * [Mercurial](https://www.mercurial-scm.org/) - version 2.2.2 or later.
 
 The directories of Git and Mercurial executables (`git` and `hg`) need to be in your system's PATH.
 
-* **Command-line compiler or IDE toolchain** - mbed CLI invokes the [mbed OS 5](https://github.com/ARMmbed/mbed-os) tools for various features, such as compiling, testing and exporting to industry standard toolchains. To compile your code, you need either a compiler or an IDE:
-    * Compilers: GCC ARM, ARM Compiler 5, IAR.
+* **Command-line compiler or IDE toolchain** - Mbed CLI invokes the [Mbed OS 5](https://github.com/ARMmbed/mbed-os) tools for various features, such as compiling, testing and exporting to industry standard toolchains. To compile your code, you need either a compiler or an IDE:
+    * Compilers: GCC ARM, Arm Compiler 5, IAR.
     * IDE: Keil uVision, DS-5, IAR Workbench.
 
-<span class="tips">**Note:** When installing the ARM Compiler 5 on a 64-bit Linux machine, you may need to also install the i386 architecture package:</span>
+<span class="tips">**Note:** When installing the Arm Compiler 5 on a 64-bit Linux machine, you may need to also install the i386 architecture package:</span>
 
 ```
 $ sudo dpkg --add-architecture i386
@@ -78,9 +78,9 @@ $ sudo apt-get install libc6:i386 libncurses5:i386 libstdc++6:i386
 
 <span class="images">[![Video tutorial](https://img.youtube.com/vi/cM0dFoTuU14/0.jpg)](https://www.youtube.com/watch?v=cM0dFoTuU14)</span>
 
-### Installing mbed CLI
+### Installing Mbed CLI
 
-You can get the latest stable version of mbed CLI through pip by running:
+You can get the latest stable version of Mbed CLI through pip by running:
 
 ```
 $ pip install mbed-cli
@@ -88,13 +88,13 @@ $ pip install mbed-cli
 
 On Linux or Mac, you may need to run with `sudo`.
 
-Alternatively, you can get the development version of mbed CLI by cloning the development repository [https://github.com/ARMmbed/mbed-cli](https://github.com/ARMmbed/mbed-cli):
+Alternatively, you can get the development version of Mbed CLI by cloning the development repository [https://github.com/ARMmbed/mbed-cli](https://github.com/ARMmbed/mbed-cli):
 
 ```
 $ git clone https://github.com/ARMmbed/mbed-cli
 ```
 
-Once cloned, you can install mbed CLI as a python package:
+Once cloned, you can install Mbed CLI as a Python package:
 
 ```
 $ python setup.py install
@@ -102,11 +102,11 @@ $ python setup.py install
 
 On Linux or Mac, you may need to run with `sudo`.
 
-<span class="tips">**Note:** mbed CLI is compatible with [Virtual Python Environment (virtualenv)](https://pypi.python.org/pypi/virtualenv). You can read more about isolated Python virtual environments [here](http://docs.python-guide.org/en/latest/).</span>
+<span class="tips">**Note:** Mbed CLI is compatible with [Virtual Python Environment (virtualenv)](https://pypi.python.org/pypi/virtualenv). You can read more about isolated Python virtual environments [here](http://docs.python-guide.org/en/latest/).</span>
 
-### Uninstalling mbed CLI
+### Uninstalling Mbed CLI
 
-To uninstall mbed CLI, run:
+To uninstall Mbed CLI, run:
 
 ```
 pip uninstall mbed-cli
@@ -114,7 +114,7 @@ pip uninstall mbed-cli
 
 ### Adding Bash tab completion
 
-To install mbed-cli bash tab completion navigate to the `tools/bash_completion` directory. Then copy the `mbed` script into your `/etc/bash_completion.d/` or `/usr/local/etc/bash_completion.d` directory and reload your terminal.  
+To install `mbed-cli` bash tab completion navigate to the `tools/bash_completion` directory. Then, copy the `mbed` script into your `/etc/bash_completion.d/` or `/usr/local/etc/bash_completion.d` directory and reload your terminal.  
 
 [Full documentation here](https://github.com/ARMmbed/mbed-cli/blob/master/tools/bash_completion/install.md)
 
@@ -124,7 +124,7 @@ To install mbed-cli bash tab completion navigate to the `tools/bash_completion` 
 
 ## Before you begin: understanding the working context and program root
 
-mbed CLI uses the current directory as a working context, in a similar way to Git, Mercurial and many other command-line tools. This means that before calling any mbed CLI command, you must first change to the directory containing the code you want to act on. For example, if you want to update the mbed OS sources in your ``mbed-example-program`` directory:
+Mbed CLI uses the current directory as a working context, in a similar way to Git, Mercurial and many other command-line tools. This means that before calling any Mbed CLI command, you must first change to the directory containing the code you want to act on. For example, if you want to update the Mbed OS sources in your `mbed-example-program` directory:
 
 ```
 $ cd mbed-example-program
@@ -132,17 +132,17 @@ $ cd mbed-os
 $ mbed update master   # This will update "mbed-os", not "my-program"
 ```
 
-Various mbed CLI features require a program root, which should be under version control - either [Git](https://git-scm.com/) or [Mercurial](https://www.mercurial-scm.org/). This makes it possible to switch between revisions of the whole program and its libraries, control the program history, synchronize the program with remote repositories, share it with others and so on. Version control is also the primary and preferred delivery mechanism for mbed OS source code, which allows everyone to contribute to mbed OS.
+Various Mbed CLI features require a program root, which should be under version control - either [Git](https://git-scm.com/) or [Mercurial](https://www.mercurial-scm.org/). This makes it possible to switch between revisions of the whole program and its libraries, control the program history, synchronize the program with remote repositories, share it with others and so on. Version control is also the primary and preferred delivery mechanism for Mbed OS source code, which allows everyone to contribute to Mbed OS.
 
-<span class="warnings">**Warning**: mbed CLI stores information about libraries and dependencies in reference files that use the `.lib` extension (such as `lib_name.lib`). Although these files are human-readable, we *strongly* advise that you don't edit these manually - let mbed CLI manage them instead.</span>
+<span class="warnings">**Warning**: Mbed CLI stores information about libraries and dependencies in reference files that use the `.lib` extension (such as `lib_name.lib`). Although these files are human-readable, we *strongly* advise that you don't edit these manually - let Mbed CLI manage them instead.</span>
 
 ## Creating and importing programs
 
-mbed CLI can create and import programs based on both mbed OS 2 and mbed OS 5.
+Mbed CLI can create and import programs based on both Mbed OS 2 and Mbed OS 5.
 
-### Creating a new program for mbed OS 5
+### Creating a new program for Mbed OS 5
 
-When you create a new program, mbed CLI automatically imports the latest [mbed OS release](https://github.com/ARMmbed/mbed-os/). Each release includes all the components: code, build tools and IDE exporters.
+When you create a new program, Mbed CLI automatically imports the latest [Mbed OS release](https://github.com/ARMmbed/mbed-os/). Each release includes all the components: code, build tools and IDE exporters.
 
 With this in mind, let's create a new program (we'll call it `mbed-os-program`):
 
@@ -153,9 +153,9 @@ $ mbed new mbed-os-program
 [mbed] Updating reference "mbed-os" -> "https://github.com/ARMmbed/mbed-os/#89962277c20729504d1d6c95250fbd36ea5f4a2d"
 ```
 
-This creates a new folder "mbed-os-program", initializes a new repository and imports the latest revision of the mbed-os dependency to your program tree.
+This creates a new folder "mbed-os-program", initializes a new repository and imports the latest revision of the `mbed-os` dependency to your program tree.
 
-<span class="tips">**Tip:** You can instruct mbed CLI to use a specific source control management system or prevent source control management initialization, by using `--scm [name|none]` option.</span>
+<span class="tips">**Tip:** You can instruct Mbed CLI to use a specific source control management system or prevent source control management initialization, by using `--scm [name|none]` option.</span>
 
 Use `mbed ls` to list all the libraries imported to your program:
 
@@ -166,11 +166,11 @@ mbed-os-program (mbed-os-program)
 `- mbed-os (https://github.com/ARMmbed/mbed-os#89962277c207)
 ```
 
-<span class="notes">**Note**: If you want to start from an existing folder in your workspace, you can use `mbed new .`, which initializes an mbed program, as well as a new Git or Mercurial repository in that folder. </span>
+<span class="notes">**Note**: If you want to start from an existing folder in your workspace, you can use `mbed new .`, which initializes an Mbed program, as well as a new Git or Mercurial repository in that folder. </span>
 
-### Creating a new program for mbed OS 2
+### Creating a new program for Mbed OS 2
 
-mbed CLI is also compatible with mbed OS 2 programs based on the [mbed library](https://mbed.org/users/mbed_official/code/mbed/), and it automatically imports the latest [mbed library release](https://mbed.org/users/mbed_official/code/mbed/) if you use the `--mbedlib` option:
+Mbed CLI is also compatible with Mbed OS 2 programs based on the [Mbed library](https://mbed.org/users/mbed_official/code/mbed/), and it automatically imports the latest [Mbed library release](https://mbed.org/users/mbed_official/code/mbed/) if you use the `--mbedlib` option:
 
 ```
 $ mbed new mbed-classic-program --mbedlib
@@ -184,7 +184,7 @@ $ mbed new mbed-classic-program --mbedlib
 
 ### Creating a new program without OS version selection
 
-You can create plain (empty) programs, without either mbed OS 5 or mbed OS 2, by using the `--create-only` option.
+You can create plain (empty) programs, without either Mbed OS 5 or Mbed OS 2, by using the `--create-only` option.
 
 ### Importing an existing program
 
@@ -197,7 +197,7 @@ $ mbed import https://github.com/ARMmbed/mbed-os-example-blinky
 $ cd mbed-os-example-blinky
 ```
 
-mbed CLI also supports programs based on mbed OS 2, which it automatically detects and which do not require additional options:
+Mbed CLI also supports programs based on Mbed OS 2, which it automatically detects and which do not require additional options:
 
 ```
 $ mbed import https://mbed.org/teams/mbed/code/mbed_blinky/
@@ -207,7 +207,7 @@ $ mbed import https://mbed.org/teams/mbed/code/mbed_blinky/
 $ cd mbed-os-example-blinky
 ```
 
-You can use the "import" command without specifying a full URL; mbed CLI adds a prefix (https://github.com/ARMmbed) to the URL if one is not present. For example, this command:
+You can use the "import" command without specifying a full URL; Mbed CLI adds a prefix (https://github.com/ARMmbed) to the URL if one is not present. For example, this command:
 
 ```
 $ mbed import mbed-os-example-blinky
@@ -240,7 +240,7 @@ While working on your code, you may need to add another library to your applicat
 
 Adding a new library to your program is not the same as cloning the repository. Don't clone a library using `hg` or `git`; use `mbed add` to add the library. This ensures that all libraries and sublibraries are populated as well.
 
-Removing a library from your program is not the same as deleting the library directory. mbed CLI updates and removes library reference files. Use `mbed remove` to remove the library; don't remove its directory with `rm`.
+Removing a library from your program is not the same as deleting the library directory. Mbed CLI updates and removes library reference files. Use `mbed remove` to remove the library; don't remove its directory with `rm`.
 
 ### Adding a library
 
@@ -264,7 +264,7 @@ If you want to specify a directory to which to add your library, you can give an
 $ mbed add https://developer.mbed.org/users/wim/code/TextLCD/ text-lcd
 ```
 
-Although mbed CLI supports this functionality, we don't encourage it. Adding a library with a name that differs from its source repository can lead to confusion.
+Although Mbed CLI supports this functionality, we don't encourage it. Adding a library with a name that differs from its source repository can lead to confusion.
 
 ### Removing a library
 
@@ -278,40 +278,40 @@ $ mbed remove text-lcd
 
 ### Toolchain selection
 
-After importing a program or creating a new one, you need to tell mbed CLI where to find the toolchains that you want to use for compiling your source tree.
+After importing a program or creating a new one, you need to tell Mbed CLI where to find the toolchains that you want to use for compiling your source tree.
 
 There are multiple ways to configure toolchain locations:
 * `mbed_settings.py` file in the root of your program. The tools will automatically create this file if it doesn't already exist.
-* The mbed CLI configuration.
+* The Mbed CLI configuration.
 * Setting an environment variable.
 * Adding directory of the compiler binary to your PATH.
 
 Methods for configuring toolchains that appear earlier in the above list override methods that appear later.
 
-#### Through mbed_settings.py
+#### Through `mbed_settings.py`
 
 Edit `mbed_settings.py` to set your toolchain:
 
-* To use the [ARM Compiler toolchain](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler-5/downloads), set `ARM_PATH` to the *base* directory of your ARM Compiler installation (example: C:\Program Files\ARM\armcc5.06). The recommended version of the ARM Compiler toolchain is 5.06.
-* To use the [GNU ARM Embedded toolchain (GCC) version 6](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads), set `GCC_ARM_PATH` to the *binary* directory of your GCC ARM installation (example: C:\Program Files\GNU Tools ARM Embedded\6 2017q2\bin). Use version 6 of GCC ARM Embedded; version 5.0 or any older version might be incompatible with the tools.
+* To use the [Arm Compiler toolchain](https://developer.arm.com/products/software-development-tools/compilers/arm-compiler-5/downloads), set `ARM_PATH` to the *base* directory of your Arm Compiler installation (example: C:\Program Files\ARM\armcc5.06). The recommended version of the Arm Compiler toolchain is 5.06.
+* To use the [GNU Arm Embedded toolchain (GCC) version 6](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads), set `GCC_ARM_PATH` to the *binary* directory of your GCC Arm installation (example: C:\Program Files\GNU Tools ARM Embedded\6 2017q2\bin). Use version 6 of GCC Arm Embedded; version 5.0 or any older version might be incompatible with the tools.
 * To use the [IAR EWARM toolchain](https://www.iar.com/iar-embedded-workbench/#!?architecture=ARM), set `IAR_PATH` to the *base* directory of your IAR installation (example: C:\Program Files (x86)\IAR Systems\Embedded Workbench 7.5\arm). Use versions 7.70 to 7.80.x of the IAR EWARM; newer (or older) versions might be incompatible with the tools.
 
 Because `mbed_settings.py` contains local settings (possibly relevant only to a single OS on a single machine), you should not check it into version control.
 
-#### Through mbed CLI configuration
+#### Through Mbed CLI configuration
 
-You can set the ARM Compiler  5 location via the command:
+You can set the Arm Compiler 5 location via the command:
 
 ```
 $ mbed config -G ARM_PATH "C:\Program Files\ARM"
 [mbed] C:\Program Files\ARM now set as global ARM_PATH
 ```
 
-The `-G` switch tells mbed CLI to set this as a global setting, rather than local for the current program.
+The `-G` switch tells Mbed CLI to set this as a global setting, rather than local for the current program.
 
 Supported settings for toolchain paths are `ARM_PATH`, `GCC_ARM_PATH` and `IAR_PATH`.
 
-You can see the active mbed CLI configuration via:
+You can see the active Mbed CLI configuration via:
 
 ```
 $ mbed config --list
@@ -323,14 +323,14 @@ IAR_PATH=C:\Program Files\IAR Workbench 7.0\arm
 No local configuration is set
 ```
 
-More information about mbed CLI configuration is available in the [configuration section](#mbed-cli-configuration) of this document.
+More information about Mbed CLI configuration is available in the [configuration section](#mbed-cli-configuration) of this document.
 
 #### Setting environment variable
 
 For each of the compilers, `mbed compile` checks a corresponding environment variable for the compiler's location. The environment variables are as follows:
-* `MBED_ARM_PATH`: The path to the *base* directory of your ARM Compiler installation. This should be the directory containing the directory containing the binaries for `armcc` and friends.
+* `MBED_ARM_PATH`: The path to the *base* directory of your Arm Compiler installation. This should be the directory containing the directory containing the binaries for `armcc` and friends.
 * `MBED_IAR_PATH`: The path to the *base* directory of your IAR EWARM Compiler installation. This should be one directory containing the directory containing the binaries for `iccarm` and friends.
-* `MBED_GCC_ARM_PATH`: The path to the *binary* directory of your GCC ARM Embedded Compiler installation. This should be the directory containing the binaries for `arm-none-eabi-gcc` and friends.
+* `MBED_GCC_ARM_PATH`: The path to the *binary* directory of your GCC Arm Embedded Compiler installation. This should be the directory containing the binaries for `arm-none-eabi-gcc` and friends.
 
 #### Compiler detection through the `PATH`
 
@@ -372,11 +372,11 @@ Image: BUILD/K64F/GCC_ARM/mbed-os-program.bin
 
 The arguments for *compile* are:
 
-* `-m <MCU>` to select a target. If `detect` or `auto` parameter is passed to `-m`, then mbed CLI detects the connected target.
-* `-t <TOOLCHAIN>` to select a toolchain (of those defined in `mbed_settings.py`, see above). The value can be `ARM` (ARM Compiler 5), `GCC_ARM` (GNU ARM Embedded) or `IAR` (IAR Embedded Workbench for ARM).
+* `-m <MCU>` to select a target. If `detect` or `auto` parameter is passed to `-m`, then Mbed CLI detects the connected target.
+* `-t <TOOLCHAIN>` to select a toolchain (of those defined in `mbed_settings.py`, see above). The value can be `ARM` (Arm Compiler 5), `GCC_ARM` (GNU Arm Embedded) or `IAR` (IAR Embedded Workbench for Arm).
 * `--source <SOURCE>` to select the source directory. The default is `.` (the current directory). You can specify multiple source locations, even outside the program tree.
 * `--build <BUILD>` to select the build directory. Default: `BUILD/` inside your program root.
-* `--profile <PATH_TO_BUILD_PROFILE>` to select a path to a build profile configuration file. Example: mbed-os/tools/profiles/debug.json.
+* `--profile <PATH_TO_BUILD_PROFILE>` to select a path to a build profile configuration file. Example: `mbed-os/tools/profiles/debug.json`.
 * `--library` to compile the code as a [static .a/.ar library](#compiling-static-libraries).
 * `--config` to inspect the runtime compile configuration (see below).
 * `-S` or `--supported` shows a matrix of the supported targets and toolchains.
@@ -392,9 +392,9 @@ For more information on build profiles, see [our build profiles](https://docs.mb
 
 ### Compiling static libraries
 
-You can build a static library of your code by adding the `--library` argument to `mbed compile`. Static libraries are useful when you want to build multiple applications from the same mbed OS codebase without having to recompile for every application. To achieve this:
+You can build a static library of your code by adding the `--library` argument to `mbed compile`. Static libraries are useful when you want to build multiple applications from the same Mbed OS codebase without having to recompile for every application. To achieve this:
 
-1. Build a static library for mbed-os.
+1. Build a static library for `mbed-os`.
 2. Compile multiple applications or tests against the static library:
 
 ```
@@ -420,7 +420,7 @@ Image: ../threaded_blinky-out/threaded_blinky.bin
 
 ### Compile configuration system
 
-The [compile configuration system](https://docs.mbed.com/docs/mbed-os-handbook/en/5.3/advanced/config_system/) provides a flexible mechanism for configuring the mbed program, its libraries and the build target.
+The [compile configuration system](https://docs.mbed.com/docs/mbed-os-handbook/en/5.3/advanced/config_system/) provides a flexible mechanism for configuring the Mbed program, its libraries and the build target.
 
 #### Inspecting the configuration
 
@@ -436,7 +436,7 @@ To display more verbose information about the configuration parameters, use `-v`
 $ mbed compile --config -t GCC_ARM -m K64F -v
 ```
 
-It's possible to filter the output of `mbed compile --config` by specifying one or more prefixes for the configuration parameters that mbed CLI displays. For example, to display only the configuration defined by the targets:
+It's possible to filter the output of `mbed compile --config` by specifying one or more prefixes for the configuration parameters that Mbed CLI displays. For example, to display only the configuration defined by the targets:
 
 ```
 $ mbed compile --config -t GCC_ARM -m K64F --prefix target
@@ -473,11 +473,11 @@ $ mbed compile -t GCC_ARM -m K64F --profile mbed-os/tools/profiles/debug.json
 
 Using `mbed target <target>` and `mbed toolchain <toolchain>`, you can set the default target and toolchain for your program. You won't have to specify these every time you compile or generate IDE project files.
 
-You can also use ``mbed target detect``, which detects the connected target board and uses it as a parameter to every subsequent compile and export.
+You can also use `mbed target detect`, which detects the connected target board and uses it as a parameter to every subsequent compile and export.
 
 ## Exporting to desktop IDEs
 
-If you need to debug your code, you can export your source tree to an IDE project file to use the IDE's debugging facilities. mbed CLI supports exporting to Keil uVision, IAR Workbench, a Makefile using GCC ARM, Eclipse using GCC ARM and other IDEs.
+If you need to debug your code, you can export your source tree to an IDE project file to use the IDE's debugging facilities. Mbed CLI supports exporting to Keil uVision, IAR Workbench, a Makefile using GCC Arm, Eclipse using GCC Arm and other IDEs.
 
 For example, to export to uVision, run:
 
@@ -485,15 +485,15 @@ For example, to export to uVision, run:
 $ mbed export -i uvision -m K64F
 ```
 
-mbed CLI creates a `.uvprojx` file in the projectfiles/uvision folder. You can open the project file with uVision.
+Mbed CLI creates a `.uvprojx` file in the projectfiles/uvision folder. You can open the project file with uVision.
 
 ## Testing
 
 Use the `mbed test` command to compile and run tests.
 
 The arguments to `test` are:
-* `-m <MCU>` to select a target for the compilation. If `detect` or `auto` parameter is passed, then mbed CLI will attempt to detect the connected target and compile against it.
-* `-t <TOOLCHAIN>` to select a toolchain (of those defined in `mbed_settings.py`, see above), where `toolchain` can be either `ARM` (ARM Compiler 5), `GCC_ARM` (GNU ARM Embedded), or `IAR` (IAR Embedded Workbench for ARM).
+* `-m <MCU>` to select a target for the compilation. If `detect` or `auto` parameter is passed, then Mbed CLI will attempt to detect the connected target and compile against it.
+* `-t <TOOLCHAIN>` to select a toolchain (of those defined in `mbed_settings.py`, see above), where `toolchain` can be either `ARM` (Arm Compiler 5), `GCC_ARM` (GNU Arm Embedded), or `IAR` (IAR Embedded Workbench for Arm).
 * `--compile-list` to list all the tests that can be built.
 * `--run-list` to list all the tests that can be run (they must be built first).
 * `--compile` to only compile the tests.
@@ -501,7 +501,7 @@ The arguments to `test` are:
 * `-n <TESTS_BY_NAME>` to limit the tests built or run to a comma separated list (ex. test1,test2,test3).
 * `--source <SOURCE>` to select the source directory. Default is `.` (the current directory). You can specify multiple source locations, even outside the program tree.
 * `--build <BUILD>` to select the build directory. Default: `BUILD/` inside your program.
-* `--profile <PATH_TO_BUILD_PROFILE>` to select a path to a build profile configuration file. Example: mbed-os/tools/profiles/debug.json.
+* `--profile <PATH_TO_BUILD_PROFILE>` to select a path to a build profile configuration file. Example: `mbed-os/tools/profiles/debug.json`.
 * `-c or --clean` to clean the build directory before compiling.
 * `--test-spec <TEST_SPEC>` to set the path for the test spec file used when building and running tests (the default path is the build directory).
 * `-v` or `--verbose` for verbose diagnostic output.
@@ -713,7 +713,7 @@ In a scenario with nested local repositories, start with the leaf repositories f
 
 ### Forking workflow
 
-Git enables a workflow where the publish/push repository may be different than the original ("origin") one. This allows new revisions in a fork repository while maintaining an association with the original repository. To use this workflow, first import an mbed OS program or mbed OS itself, and then associate the push remote with your fork. For example:
+Git enables a workflow where the publish/push repository may be different than the original ("origin") one. This allows new revisions in a fork repository while maintaining an association with the original repository. To use this workflow, first import an Mbed OS program or Mbed OS itself, and then associate the push remote with your fork. For example:
 
 ```
 $ git remote set-url --push origin https://github.com/screamerbg/repo-fork
@@ -721,19 +721,19 @@ $ git remote set-url --push origin https://github.com/screamerbg/repo-fork
 
 Both `git commit & git push` and `mbed publish` push the new revisions to your fork. You can fetch from the original repository using `mbed update` or `git pull`. If you explicitly want to fetch or pull from your fork, then you can use `git pull https://github.com/screamerbg/repo-fork [branch]`.
 
-Through the workflow explained above, mbed CLI maintains association to the original repository (which you may want to send a pull request to) and will record references with the revision hashes that you push to your fork. Until your pull request (PR) is accepted, all recorded references are invalid. Once the PR is accepted, all revision hashes from your fork become part the original repository, making them valid.
+Through the workflow explained above, Mbed CLI maintains association to the original repository (which you may want to send a pull request to) and records references with the revision hashes that you push to your fork. Until your pull request (PR) is accepted, all recorded references are invalid. Once the PR is accepted, all revision hashes from your fork become part the original repository, making them valid.
 
 ## Updating programs and libraries
 
 You can update programs and libraries on your local machine so that they pull in changes from the remote sources (Git or Mercurial).
 
-As with any mbed CLI command, `mbed update` uses the current directory as a working context. Before calling `mbed update`, you should change your working directory to the one you want to update. For example, if you're updating mbed-os, use `cd mbed-os` before you begin updating.
+As with any Mbed CLI command, `mbed update` uses the current directory as a working context. Before calling `mbed update`, you should change your working directory to the one you want to update. For example, if you're updating `mbed-os`, use `cd mbed-os` before you begin updating.
 
-<span class="tips">**Tip: Synchronizing library references:** Before triggering an update, you may want to synchronize any changes that you've made to the program structure by running ``mbed sync``, which updates the necessary library references and removes the invalid ones.</span>
+<span class="tips">**Tip: Synchronizing library references:** Before triggering an update, you may want to synchronize any changes that you've made to the program structure by running `mbed sync`, which updates the necessary library references and removes the invalid ones.</span>
 
 ### Protection against overwriting local changes
 
-The update command fails if there are changes in your program or library that `mbed update` could overwrite. This is by design. mbed CLI does not run operations that would result in overwriting uncommitted local changes. If you get an error, take care of your local changes (commit or use one of the options below), and then rerun `mbed update`.
+The update command fails if there are changes in your program or library that `mbed update` could overwrite. This is by design. Mbed CLI does not run operations that would result in overwriting uncommitted local changes. If you get an error, take care of your local changes (commit or use one of the options below), and then rerun `mbed update`.
 
 ### Updating to an upstream version
 
@@ -771,32 +771,33 @@ Run `mbed update [branch|revision|tag_name]`. You might have to commit or stash 
 
 Run `mbed update [branch|revision|tag_name] --clean`
 
-Specifying a branch to `mbed update` will only check out that branch and won't automatically merge or fast-forward to the remote/upstream branch. You can run `mbed update` to merge (fast-forward) your local branch with the latest remote branch. On Git you can do `git pull`.
+Specifying a branch to `mbed update` will only check out that branch and won't automatically merge or fast-forward to the remote/upstream branch. You can run `mbed update` to merge (fast-forward) your local branch with the latest remote branch. On Git, you can do `git pull`.
 
-<span class="warnings">**Warning**: The `--clean` option tells mbed CLI to update that program or library and its dependencies and discard all local changes. This action cannot be undone; use with caution.</span>
+<span class="warnings">**Warning**: The `--clean` option tells Mbed CLI to update that program or library and its dependencies and discard all local changes. This action cannot be undone; use with caution.</span>
 
 #### Combining update options
 
-You can combine the options of the mbed update command for the following scenarios:
+You can combine the options of the Mbed update command for the following scenarios:
 
 * `mbed update --clean --clean-deps --clean-files` - Update the current program or library and its dependencies, remove all local unpublished libraries, discard local uncommitted changes and remove all untracked or ignored files. This wipes every single change that you made in the source tree and restores the stock layout.
 
-* `mbed update --clean --ignore` - Update the current program or library and its dependencies, but ignore any local repositories. mbed CLI will update whatever it can from the public repositories.
+* `mbed update --clean --ignore` - Update the current program or library and its dependencies, but ignore any local repositories. Mbed CLI updates whatever it can from the public repositories.
 
 Use these with caution because your uncommitted changes and unpublished libraries cannot be restored.
 
-## mbed CLI configuration
+## Mbed CLI configuration
 
-You can streamline many options in mbed CLI with global and local configuration.
+You can streamline many options in Mbed CLI with global and local configuration.
 
-The mbed CLI configuration syntax is:
+The Mbed CLI configuration syntax is:
+
 ```
 mbed config [--global] <var> [value] [--unset]
 ```
 
-* The **global** configuration (via `--global` option) defines the default behavior of mbed CLI across programs unless overridden by *local* settings.
-* The **local** configuration (without `--global`) is specific to mbed program and allows overriding of global or default mbed CLI settings.
-* If you do not specify a value, then mbed CLI prints the value for this setting in this context.
+* The **global** configuration (via `--global` option) defines the default behavior of Mbed CLI across programs unless overridden by *local* settings.
+* The **local** configuration (without `--global`) is specific to the Mbed program and allows overriding of global or default Mbed CLI settings.
+* If you do not specify a value, then Mbed CLI prints the value for this setting in this context.
 * The `--unset` option allows you to remove a setting.
 * The `--list` option allows you to list global and local configuration.
 
@@ -804,10 +805,10 @@ Here is a list of configuration settings and their defaults:
 
  * `target` - defines the default target for `compile`, `test` and `export`; an alias of `mbed target`. Default: none.
  * `toolchain` - defines the default toolchain for `compile` and `test`; can be set through `mbed toolchain`. Default: none.
- * `ARM_PATH`, `GCC_ARM_PATH`, `IAR_PATH` - defines the path to ARM Compiler, GCC ARM and IAR Workbench toolchains. Default: none.
+ * `ARM_PATH`, `GCC_ARM_PATH`, `IAR_PATH` - defines the path to Arm Compiler, GCC Arm and IAR Workbench toolchains. Default: none.
  * `protocol` - defines the default protocol used for importing or cloning of programs and libraries. The possible values are `https`, `http` and `ssh`. Use `ssh` if you have generated and registered SSH keys (Public Key Authentication) with a service such as GitHub, GitLab, Bitbucket and so on. Read more about SSH keys [here](https://help.github.com/articles/generating-an-ssh-key/). Default: `https`.
  * `depth` - defines the *clone* depth for importing or cloning and applies only to *Git* repositories. Note that though this option may improve cloning speed, it may also prevent you from correctly checking out a dependency tree when the reference revision hash is older than the clone depth. Read more about shallow clones [here](https://git-scm.com/docs/git-clone). Default: none.
- * `cache` - defines the local path that stores small copies of the imported or cloned repositories, and mbed CLI uses it to minimize traffic and speed up future imports of the same repositories. Use `on` or `enabled` to turn on caching in the system temp path. Use `none` to turn caching off. Default: none (disabled).
+ * `cache` - defines the local path that stores small copies of the imported or cloned repositories, and Mbed CLI uses it to minimize traffic and speed up future imports of the same repositories. Use `on` or `enabled` to turn on caching in the system temp path. Use `none` to turn caching off. Default: none (disabled).
 
 ## Troubleshooting
 
@@ -816,5 +817,5 @@ Here is a list of configuration settings and their defaults:
 
 2. Try to clone a Mercurial repository directly. For example, `hg clone https://developer.mbed.org/teams/mbed/code/mbed_blinky/`. If you receive an error similar to `abort: error: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.:590)`, then your system certificates are out of date. You need to update your system certificates and possibly add the host certificate fingerprint of `mbed.com` and `mbed.org`. Read more about Mercurial's certificate management [here](https://www.mercurial-scm.org/wiki/CACertificates).
 
-### Various issues when running mbed CLI in Cygwin environment
-Currently mbed CLI is not compatible with Cygwin environment and cannot be executed inside it (https://github.com/ARMmbed/mbed-cli/issues/299).
+### Various issues when running Mbed CLI in Cygwin environment
+Currently Mbed CLI is not compatible with Cygwin environment and cannot be executed inside it (https://github.com/ARMmbed/mbed-cli/issues/299).


### PR DESCRIPTION
Change capitalization to match new branding rollout, and fix a few typos while I'm at it.