### PR TITLE
Add link to mbed CLI for Windows Installer (supercedes PR 540)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ $ sudo apt-get install libc6:i386 libncurses5:i386 libstdc++6:i386
 
 ### Installing Mbed CLI
 
+Windows users can use the [mbed CLI for Windows installer](https://docs.mbed.com/docs/mbed-os-handbook/en/latest/dev_tools/cli_install/) which will install mbed CLI and all necessary requirements with one installer.
+
 You can get the latest stable version of Mbed CLI through pip by running:
 
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ sudo apt-get install libc6:i386 libncurses5:i386 libstdc++6:i386
 
 ### Installing Mbed CLI
 
-Windows users can use the [mbed CLI for Windows installer](https://docs.mbed.com/docs/mbed-os-handbook/en/latest/dev_tools/cli_install/) which will install mbed CLI and all necessary requirements with one installer.
+Windows users can use the [Mbed CLI for Windows installer](https://docs.mbed.com/docs/mbed-os-handbook/en/latest/dev_tools/cli_install/) to install Mbed CLI and all necessary requirements with one installer.
 
 You can get the latest stable version of Mbed CLI through pip by running:
 


### PR DESCRIPTION
Added a reference to the mbed CLI for Windows Installer in the Installation section.

This information was not immediately obvious and I think it would be valuable to have this information more prominent in this doc.

This pull request supercedes PR 540: I did a merge rather than a rebase in 540. This PR includes the original commit plus it has been rebased from latest version of master: b6b070c
@screamerbg @AnotherButler 