### PR TITLE
Properly performs shallow clone when `depth` is used

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1741,7 +1741,6 @@ def new(name, scm='git', program=False, library=False, mbedlib=False, create_onl
         p.set_root()
         if not create_only and not p.get_os_dir() and not p.get_mbedlib_dir():
             url = mbed_lib_url if mbedlib else mbed_os_url+"#latest"
-            print(url)
             d = 'mbed' if mbedlib else 'mbed-os'
             try:
                 with cd(d_path):
@@ -1828,7 +1827,6 @@ def import_(url, path=None, ignore=False, depth=None, protocol=None, top=True):
         deploy(ignore=ignore, depth=depth, protocol=protocol, top=False)
 
     if top:
-        action("Post action.");
         Program(repo.path).post_action()
 
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -610,7 +610,7 @@ class Git(object):
     def clone(url, path, rev=None, depth=None, protocol=None, name=None):
         result = pquery([git_cmd, "ls-remote", url, (rev if rev else "HEAD")])
         
-        if result:
+        if result and rev:
             repo_name = url.split('/')[-1]
             if '.git' in repo_name:
                 repo_name = repo_name[:-4]
@@ -624,6 +624,7 @@ class Git(object):
                 popen([git_cmd, 'remote', 'add', 'origin', url])
             
         else:
+            print("Cloning...")
             popen([git_cmd, 'clone', formaturl(url, protocol), path] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
 
     def add(dest):
@@ -660,7 +661,10 @@ class Git(object):
 
     def fetch(url=None, rev=None, depth=None):
         info("Fetching revisions from remote repository to \"%s\"" % os.path.basename(os.getcwd()))
-        popen([git_cmd, 'fetch', '--tags'] + ([url] if url else []) + ([rev] if rev else ['--all']) + (['--depth', depth] if depth else []) + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+        if url:
+            popen([git_cmd, 'fetch', '--tags'] + ([url] if url else []) + ([rev] if rev else []) + (["--depth", depth] if depth else []) + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+        else:
+            popen([git_cmd, 'fetch', '--tags', '--all'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
 
     def discard(clean_files=False):
         info("Discarding local changes in \"%s\"" % os.path.basename(os.getcwd()))

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -624,7 +624,6 @@ class Git(object):
                 popen([git_cmd, 'remote', 'add', 'origin', url])
             
         else:
-            print("Cloning...")
             popen([git_cmd, 'clone', formaturl(url, protocol), path] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
 
     def add(dest):
@@ -1744,12 +1743,11 @@ def new(name, scm='git', program=False, library=False, mbedlib=False, create_onl
         p.path = cwd_root
         p.set_root()
         if not create_only and not p.get_os_dir() and not p.get_mbedlib_dir():
-            url = mbed_lib_url if mbedlib else mbed_os_url+"#latest"
+            url = mbed_lib_url if mbedlib else mbed_os_url+'#latest'
             d = 'mbed' if mbedlib else 'mbed-os'
             try:
                 with cd(d_path):
                     add(url, depth=depth, protocol=protocol, top=False)
-
             except Exception as e:
                 if os.path.isdir(os.path.join(d_path, d)):
                     rmtree_readonly(os.path.join(d_path, d))
@@ -1821,7 +1819,7 @@ def import_(url, path=None, ignore=False, depth=None, protocol=None, top=True):
             warning(err)
         else:
             error(err, 1)
-   
+
     repo.sync()
 
     if top: # This helps sub-commands to display relative paths to the imported program
@@ -1857,8 +1855,8 @@ def add(url, path=None, ignore=False, depth=None, protocol=None, top=True):
     lib.write()
     repo.add(lib.lib)
 
-    #if top:
-    #    Program(repo.path).post_action()
+    if top:
+        Program(repo.path).post_action()
 
 
 # Remove library

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -281,7 +281,7 @@ class Bld(object):
                 else:
                     shutil.rmtree(fl)
 
-    def clone(url, path=None, depth=None, protocol=None):
+    def clone(url, path=None, rev=None, depth=None, protocol=None):
         m = Bld.isurl(url)
         if not m:
             raise ProcessException(1, "Not a library build URL")
@@ -395,7 +395,7 @@ class Hg(object):
     def cleanup():
         return True
 
-    def clone(url, name=None, depth=None, protocol=None):
+    def clone(url, name=None, rev=None, depth=None, protocol=None):
         popen([hg_cmd, 'clone', formaturl(url, protocol), name] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
 
     def add(dest):


### PR DESCRIPTION
When `depth` flag is used, `clone` will attempt to pull only a single commit from repos.

If a SHA in a .lib file does not match a repo ref, the `clone` will revert to the default behavior of pulling the entire repo and checking out the specific SHA.

References: 
https://github.com/ARMmbed/mbed-cli/issues/560
https://github.com/ARMmbed/mbed-cli/issues/561