### PR TITLE
New feature: mbed releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Use `mbed ls` to list all the libraries imported to your program:
 $ cd mbed-os-program
 $ mbed ls
 mbed-os-program (no revision)
-`- mbed-os (#182bbd51bc8d, tags:latest, mbed-os-5.6.5)
+`- mbed-os (#182bbd51bc8d, tags: latest, mbed-os-5.6.5)
 ```
 
 Use `mbed releases` to list all releases in a program or library:
@@ -173,7 +173,7 @@ Use `mbed releases` to list all releases in a program or library:
 ```
 $ cd mbed-os
 $ mbed releases
-mbed-os (#182bbd51bc8d, tags:latest, mbed-os-5.6.5)
+mbed-os (#182bbd51bc8d, tags: latest, mbed-os-5.6.5)
   ...
   * mbed-os-5.6.0 
   * mbed-os-5.6.1 
@@ -702,7 +702,7 @@ Let's assume that the list of dependencies of your program (obtained by running 
 
 ```
 my-mbed-os-example (#a5ac4bf2e468)
-|- mbed-os (#182bbd51bc8d, tags:latest, mbed-os-5.6.5)
+|- mbed-os (#182bbd51bc8d, tags: latest, mbed-os-5.6.5)
 `- my-libs (#e39199afa2da)
    |- my-libs/iot-client (#571cfef17dd0)
    `- my-libs/test-framework (#cd18b5a50df4)
@@ -756,14 +756,14 @@ The update command fails if there are changes in your program or library that `m
 
 ### Updating to an upstream version
 
-Before updating a program or a library, it's good to know the names of the stable releases, usually marked with a tag using a common format, such as `1.2`, `v1.0.1`, `r5.6`, `mbed-os-5.6` and so on.
+Before updating a program or a library, it's good to know the names of the stable releases, usually marked with a tag using a common format, such as `1.2`, `v1.0.1`, `r5.6`, `mbed-os-5.6` and so on. 
 
 You can find stable release versions of a program or a library using the `mbed releases` command:
 
 ```
 $ cd mbed-os
 $ mbed releases
-mbed-os (#182bbd51bc8d, tags:latest, mbed-os-5.6.5)
+mbed-os (#182bbd51bc8d, tags: latest, mbed-os-5.6.5)
   ...
   * mbed-os-5.6.0 
   * mbed-os-5.6.1 
@@ -780,7 +780,7 @@ Lastly, you can list unstable releases, such as release candidates, alphas and b
 ```
 $ cd mbed-client
 $ mbed releases -u
-mbed-client (#31e5ce203cc0, tags:v3.0.0)
+mbed-client (#31e5ce203cc0, tags: v3.0.0)
   * mbed-os-5.0-rc1 
   * mbed-os-5.0-rc2 
   * r0.5-rc4 
@@ -791,6 +791,8 @@ mbed-client (#31e5ce203cc0, tags:v3.0.0)
 ```
 
 You can use the `-a` switch to print release and revision hash pairs.
+
+Mbed CLI recognizes stable release if the tags are in standard versioning format, such as `MAJOR[.MINOR][.PATCH][.BUILD]`, and optionally prefixed with either `v`, `r` or `mbed-os`. Unstable releases can be suffixed with any letter/number/hyphen/dot combination.
 
 #### Updating a program
 

--- a/README.md
+++ b/README.md
@@ -163,9 +163,24 @@ Use `mbed ls` to list all the libraries imported to your program:
 
 ```
 $ cd mbed-os-program
-$ mbed ls -a
-mbed-os-program (mbed-os-program)
-`- mbed-os (https://github.com/ARMmbed/mbed-os#89962277c207)
+$ mbed ls
+mbed-os-program (no revision)
+`- mbed-os (#182bbd51bc8d, tags:latest, mbed-os-5.6.5)
+```
+
+Use `mbed releases` to list all releases in a program or library:
+
+```
+$ cd mbed-os
+$ mbed releases
+mbed-os (#182bbd51bc8d, tags:latest, mbed-os-5.6.5)
+  ...
+  * mbed-os-5.6.0 
+  * mbed-os-5.6.1 
+  * mbed-os-5.6.2 
+  * mbed-os-5.6.3 
+  * mbed-os-5.6.4 
+  * mbed-os-5.6.5  <- current
 ```
 
 <span class="notes">**Note**: If you want to start from an existing folder in your workspace, you can use `mbed new .`, which initializes an Mbed program, as well as a new Git or Mercurial repository in that folder. </span>
@@ -686,11 +701,11 @@ To push the changes in your local tree upstream, run `mbed publish`. `mbed publi
 Let's assume that the list of dependencies of your program (obtained by running `mbed ls`) looks like this:
 
 ```
-my-mbed-os-example (a5ac4bf2e468)
-|- mbed-os (5fea6e69ec1a)
-`- my-libs (e39199afa2da)
-   |- my-libs/iot-client (571cfef17dd0)
-   `- my-libs/test-framework (cd18b5a50df4)
+my-mbed-os-example (#a5ac4bf2e468)
+|- mbed-os (#182bbd51bc8d, tags:latest, mbed-os-5.6.5)
+`- my-libs (#e39199afa2da)
+   |- my-libs/iot-client (#571cfef17dd0)
+   `- my-libs/test-framework (#cd18b5a50df4)
 ```
 
 Let's assume that you make changes to `iot-client`. `mbed publish` detects the change on the leaf `iot-client` dependency and asks you to commit it. Then `mbed publish` detects that `my-libs` depends on `iot-client`, updates the `my-libs` dependency on `iot-client` to its latest version by updating the `iot-client.lib` file and asks you to commit it. This propagates up to `my-libs` and finally to your program, `my-mbed-os-example`.
@@ -741,6 +756,42 @@ The update command fails if there are changes in your program or library that `m
 
 ### Updating to an upstream version
 
+Before updating a program or a library, it's good to know the names of the stable releases, usually marked with a tag using a common format, e.g. 1.2, v1.0.1, r5.6, mbed-os-5.6, etc.
+
+You can find stable release versions of a program or a library using the `mbed releases` command:
+
+```
+$ cd mbed-os
+$ mbed releases
+mbed-os (#182bbd51bc8d, tags:latest, mbed-os-5.6.5)
+  ...
+  * mbed-os-5.6.0 
+  * mbed-os-5.6.1 
+  * mbed-os-5.6.2 
+  * mbed-os-5.6.3 
+  * mbed-os-5.6.4 
+  * mbed-os-5.6.5  <- current
+```
+
+You can also recursively list stable releases for your program and libraries using the `-r` switch, e.g. `mbed releases -r`. The output of this command is usually long, thus it's not included in this documentation.
+
+Lastly, you can list unstable releases, like release candidates, alphas, betas, using the `-u` switch.
+```
+$ cd mbed-client
+$ mbed releases -u
+mbed-client (#31e5ce203cc0, tags:v3.0.0)
+  * mbed-os-5.0-rc1 
+  * mbed-os-5.0-rc2 
+  * r0.5-rc4 
+  ...
+  * v2.2.0 
+  * v2.2.1 
+  * v3.0.0  <- current
+```
+
+You can use the `-a` switch to print out release and revision hash pairs.
+
+
 #### Updating a program
 
 To update your program to another upstream version, go to the root folder of the program, and run:
@@ -750,6 +801,7 @@ $ mbed update [branch|tag|revision]
 ```
 
 This fetches new revisions from the remote repository, updating the program to the specified branch, tag or revision. If you don't specify any of these, then `mbed update` updates to the latest revision of the current branch. `mbed update` performs this series of actions recursively against all dependencies in the program tree.
+
 
 #### Updating a library
 
@@ -769,11 +821,11 @@ There are two main scenarios when updating:
 
 * Update with local uncommitted changes: *dirty* update.
 
-Run `mbed update [branch|revision|tag_name]`. You might have to commit or stash your changes if the source control tool (Git or Mercurial) throws an error that the update will overwrite local changes.
+Run `mbed update [branch|tag|revision]`. You might have to commit or stash your changes if the source control tool (Git or Mercurial) throws an error that the update will overwrite local changes.
 
 * Discard local uncommitted changes: *clean* update.
 
-Run `mbed update [branch|revision|tag_name] --clean`
+Run `mbed update [branch|tag|revision] --clean`
 
 Specifying a branch to `mbed update` will only check out that branch and won't automatically merge or fast-forward to the remote/upstream branch. You can run `mbed update` to merge (fast-forward) your local branch with the latest remote branch. On Git, you can do `git pull`.
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,13 +7,18 @@ test:
         - mbed config -G protocol ssh
         - cd .tests && mbed new new-test
         - cd .tests/new-test && mbed ls
+        - cd .tests/new-test && mbed releases -r
         - cd .tests/new-test && mbed compile --source=. --source=mbed-os/TESTS/integration/basic -j 0
         - cd .tests/new-test && mbed test --compile -n mbed-os-tests-integration-basic -j 0
         - cd .tests && mbed import https://developer.mbed.org/teams/Morpheus/code/mbed-Client-Morpheus-hg hg-test
+        - cd .tests/hg-test && mbed ls
+        - cd .tests/hg-test && mbed releases -r
         - cd .tests/hg-test && mbed update b02527cafcde8612ff051fea57e9975aca598807 --clean
         - cd .tests/hg-test && mbed update --clean
         - cd .tests/hg-test && mbed compile -j 0
         - cd .tests && mbed import https://developer.mbed.org/users/samux/code/USBSerial_HelloWorld bld-test
+        - cd .tests/bld-test && mbed ls
+        - cd .tests/bld-test && mbed releases -r
         - cd .tests/bld-test/mbed && mbed update 85 --clean
         - cd .tests/bld-test && mbed update --clean
         - cd .tests/bld-test && mbed compile -m LPC1768 -j 0

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -816,6 +816,7 @@ class Git(object):
         for ref in refs:
             m = re.match(r'^(.+)\s+refs\/tags\/(.+)$', ref)
             if m and (not rev or m.group(1).startswith(rev)):
+                t = m.group(2)
                 if re.match(r'^(.+)\^\{\}$', t): # detect tag "pointer"
                     t = re.sub(r'\^\{\}$', '', t) # remove "pointer" chars, e.g. some-tag^{}
                     for tag in tags:

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2198,7 +2198,7 @@ def releases_(detailed=False, unstable=False, recursive=False, prefix='', p_path
     rels = []
     for tag in tags:
         if re.match(regex_rels, tag[1]):
-            rels.append(tag[1] + " %s%s" % (tag[0] if detailed else "", " <- current" if tag[1] in revtags else ""))
+            rels.append(tag[1] + " %s%s" % ('#'+tag[0] if detailed else "", " <- current" if tag[1] in revtags else ""))
 
     # print header
     print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url+('#'+str(repo.rev)[:12] if repo.rev else '') if detailed else revstr) or 'no revision'))

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -526,7 +526,7 @@ class Hg(object):
         for ref in refs:
             m = re.match(r'^(.+?)\s+(\d+)\:([a-f0-9]+)$', ref)
             if m and (not rev or m.group(1).startswith(rev)):
-                tags.append(t if rev else [m.group(3), m.group(1)])
+                tags.append(m.group(1) if rev else [m.group(3), m.group(1)])
         return tags
 
     def remoteid(url, rev=None):
@@ -2204,7 +2204,7 @@ def releases_(detailed=False, unstable=False, recursive=False, prefix='', p_path
 
     # Print list of tags
     rprefix = (prefix[:-3] + ('|  ' if prefix[-3] == '|' else '   ')) if recursive and prefix else ''
-    rprefix += '| ' if recursive and len(repo.libs)>1 else '  '
+    rprefix += '| ' if recursive and len(repo.libs) > 1 else '  '
     if len(rels):
         for rel in rels:
             print rprefix+'* '+rel

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -823,7 +823,6 @@ class Git(object):
                         for tag in tags:
                             if tag[1] == t:
                                 tags.remove(tag)
-                        #tags = {key:tag for key, tag in tags.items() if tag != t} # remove duplicate 
                     tags.append(t if rev else [m.group(1), t])
         return tags
 
@@ -2179,7 +2178,7 @@ def list_(detailed=False, prefix='', p_path=None, ignore=False):
                 list_(detailed, nprefix, repo.path, ignore=ignore)
 
 
-# Command status for cross-SCM status of repositories
+# Command release for cross-SCM release tags of repositories
 @subcommand('releases',
     dict(name=['-a', '--all'], dest='detailed', action='store_true', help='Show revision hashes'),
     dict(name=['-u', '--unstable'], dest='unstable', action='store_true', help='Show unstable releases well, e.g. release candidates, alphas, betas, etc'),
@@ -2200,10 +2199,10 @@ def releases_(detailed=False, unstable=False, recursive=False, prefix='', p_path
         if re.match(regex_rels, tag[1]):
             rels.append(tag[1] + " %s%s" % ('#'+tag[0] if detailed else "", " <- current" if tag[1] in revtags else ""))
 
-    # print header
+    # Print header
     print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url+('#'+str(repo.rev)[:12] if repo.rev else '') if detailed else revstr) or 'no revision'))
 
-    # print list of tags
+    # Print list of tags
     rprefix = (prefix[:-3] + ('|  ' if prefix[-3] == '|' else '   ')) if recursive and prefix else ''
     rprefix += '| ' if recursive and len(repo.libs)>1 else '  '
     if len(rels):

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -814,16 +814,14 @@ class Git(object):
         tags = []
         refs = Git.getrefs()
         for ref in refs:
-            m = re.match(r'^(.+)\s+(.+)$', ref)
+            m = re.match(r'^(.+)\s+refs\/tags\/(.+)$', ref)
             if m and (not rev or m.group(1).startswith(rev)):
-                if re.match(r'refs\/tags\/', m.group(2)): # only tags
-                    t = re.sub(r'refs\/tags\/', '', m.group(2))
-                    if re.match(r'^(.+)\^\{\}$', t): # detect tag "symlink"
-                        t = re.sub(r'\^\{\}$', '', t) # remove "symlink" chars, e.g. some-tag^{}
-                        for tag in tags:
-                            if tag[1] == t:
-                                tags.remove(tag)
-                    tags.append(t if rev else [m.group(1), t])
+                if re.match(r'^(.+)\^\{\}$', t): # detect tag "pointer"
+                    t = re.sub(r'\^\{\}$', '', t) # remove "pointer" chars, e.g. some-tag^{}
+                    for tag in tags:
+                        if tag[1] == t:
+                            tags.remove(tag)
+                tags.append(t if rev else [m.group(1), t])
         return tags
 
     # Finds branches a rev belongs to

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2181,26 +2181,27 @@ def list_(detailed=False, prefix='', p_path=None, ignore=False):
 
 # Command status for cross-SCM status of repositories
 @subcommand('releases',
-    dict(name=['-a', '--all'], dest='all_refs', action='store_true', help='Show all releases, including release candidates, alphas, betas, etc'),
+    dict(name=['-a', '--all'], dest='detailed', action='store_true', help='Show revision hashes'),
+    dict(name=['-u', '--unstable'], dest='unstable', action='store_true', help='Show unstable releases well, e.g. release candidates, alphas, betas, etc'),
     dict(name=['-r', '--recursive'], action='store_true', help='Show release tags for all libraries and sub-libraries as well'),
     help='Show release tags',
     description=(
         "Show release tags for the current program or library."))
-def releases_(all_refs=False, recursive=False, prefix='', p_path=None):
+def releases_(detailed=False, unstable=False, recursive=False, prefix='', p_path=None):
     repo = Repo.fromrepo()
     tags = repo.scm.gettags()
     revtags = repo.scm.gettags(repo.rev)  if repo.rev else [] # associated tags with current commit
     revstr = ('#'+repo.rev[:12]+(', tags:'+', '.join(revtags[0:2]) if len(revtags) else '')) if repo.rev else ''
-    regex_rels = regex_rels_all if all_refs else regex_rels_official
+    regex_rels = regex_rels_all if unstable else regex_rels_official
 
     # Generate list of tags
     rels = []
     for tag in tags:
         if re.match(regex_rels, tag[1]):
-            rels.append(tag[1] + " %s%s" % (tag[0] if verbose else "", " <- current" if tag[1] in revtags else ""))
+            rels.append(tag[1] + " %s%s" % (tag[0] if detailed else "", " <- current" if tag[1] in revtags else ""))
 
     # print header
-    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url+('#'+str(repo.rev)[:12] if repo.rev else '') if verbose else revstr) or 'no revision'))
+    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url+('#'+str(repo.rev)[:12] if repo.rev else '') if detailed else revstr) or 'no revision'))
 
     # print list of tags
     rprefix = (prefix[:-3] + ('|  ' if prefix[-3] == '|' else '   ')) if recursive and prefix else ''
@@ -2218,7 +2219,7 @@ def releases_(all_refs=False, recursive=False, prefix='', p_path=None):
 
             if lib.check_repo():
                 with cd(lib.path):
-                    releases_(all_refs, recursive, nprefix, repo.path)
+                    releases_(detailed, unstable, recursive, nprefix, repo.path)
 
 
 # Command status for cross-SCM status of repositories

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2163,7 +2163,7 @@ def sync(recursive=True, keep_refs=False, top=True):
 def list_(detailed=False, prefix='', p_path=None, ignore=False):
     repo = Repo.fromrepo()
     revtags = repo.scm.gettags(repo.rev) if repo.rev else []
-    revstr = ('#'+repo.rev[:12]+(', tags:'+', '.join(revtags[0:2]) if len(revtags) else '')) if repo.rev else ''
+    revstr = ('#'+repo.rev[:12]+(', tags: '+', '.join(revtags[0:2]) if len(revtags) else '')) if repo.rev else ''
 
     print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url+('#'+str(repo.rev)[:12] if repo.rev else '') if detailed else revstr) or 'no revision'))
 
@@ -2188,7 +2188,7 @@ def releases_(detailed=False, unstable=False, recursive=False, prefix='', p_path
     repo = Repo.fromrepo()
     tags = repo.scm.gettags()
     revtags = repo.scm.gettags(repo.rev)  if repo.rev else [] # associated tags with current commit
-    revstr = ('#'+repo.rev[:12]+(', tags:'+', '.join(revtags[0:2]) if len(revtags) else '')) if repo.rev else ''
+    revstr = ('#'+repo.rev[:12]+(', tags: '+', '.join(revtags[0:2]) if len(revtags) else '')) if repo.rev else ''
     regex_rels = regex_rels_all if unstable else regex_rels_official
 
     # Generate list of tags

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -37,7 +37,7 @@ import tempfile
 
 
 # Application version
-ver = '1.2.1'
+ver = '1.2.2'
 
 # Default paths to Mercurial and Git
 hg_cmd = 'hg'
@@ -2192,7 +2192,7 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
         source = [os.path.relpath(program.path, orig_path)]
 
     if supported:
-        popen(['python', '-u', os.path.join(tools_dir, 'make.py')]
+        popen([python_cmd, '-u', os.path.join(tools_dir, 'make.py')]
               + (['-S', supported] if supported else []) + (['-v'] if very_verbose else [])
               + (['--app-config', app_config] if app_config else [])
               + args,
@@ -2404,7 +2404,7 @@ def export(ide=None, target=None, source=False, clean=False, supported=False, ap
     env = program.get_env()
 
     if supported:
-        popen(['python', '-u', os.path.join(tools_dir, 'project.py')]
+        popen([python_cmd, '-u', os.path.join(tools_dir, 'project.py')]
               + (['-S', supported] if supported else []) + (['-v'] if very_verbose else []),
               env=env)
         return

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -803,10 +803,9 @@ class Git(object):
         result = []
         refs = Git.getrefs()
         for ref in refs:
-            m = re.match(r'^(.+)\s+(.+)$', ref)
+            m = re.match(r'^(.+)\s+refs\/(heads|remotes)\/(.+)$', ref)
             if m and (not rev or m.group(1).startswith(rev)):
-                if re.match(r'refs\/(heads|remotes)\/', m.group(2)): # exclude tags
-                    result.append(m.group(1) if ret_rev else re.sub(r'refs\/(heads|remotes)\/', '', m.group(2)))
+                result.append(m.group(1) if ret_rev else m.group(3))
         return result
 
     # Finds tags. Will match rev if specified
@@ -2164,9 +2163,9 @@ def sync(recursive=True, keep_refs=False, top=True):
 def list_(detailed=False, prefix='', p_path=None, ignore=False):
     repo = Repo.fromrepo()
     revtags = repo.scm.gettags(repo.rev) if repo.rev else []
-    revstr = ('#'+repo.rev[:12]+(', tags: '+', '.join(revtags[0:2]) if len(revtags) else '')) if repo.rev else ''
+    revstr = ('#' + repo.rev[:12] + (', tags: ' + ', '.join(revtags[0:2]) if len(revtags) else '')) if repo.rev else ''
 
-    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url+('#'+str(repo.rev)[:12] if repo.rev else '') if detailed else revstr) or 'no revision'))
+    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url + ('#' + str(repo.rev)[:12] if repo.rev else '') if detailed else revstr) or 'no revision'))
 
     for i, lib in enumerate(sorted(repo.libs, key=lambda l: l.path)):
         nprefix = (prefix[:-3] + ('|  ' if prefix[-3] == '|' else '   ')) if prefix else ''
@@ -2189,26 +2188,26 @@ def releases_(detailed=False, unstable=False, recursive=False, prefix='', p_path
     repo = Repo.fromrepo()
     tags = repo.scm.gettags()
     revtags = repo.scm.gettags(repo.rev)  if repo.rev else [] # associated tags with current commit
-    revstr = ('#'+repo.rev[:12]+(', tags: '+', '.join(revtags[0:2]) if len(revtags) else '')) if repo.rev else ''
+    revstr = ('#' + repo.rev[:12] + (', tags: ' + ', '.join(revtags[0:2]) if len(revtags) else '')) if repo.rev else ''
     regex_rels = regex_rels_all if unstable else regex_rels_official
 
     # Generate list of tags
     rels = []
     for tag in tags:
         if re.match(regex_rels, tag[1]):
-            rels.append(tag[1] + " %s%s" % ('#'+tag[0] if detailed else "", " <- current" if tag[1] in revtags else ""))
+            rels.append(tag[1] + " %s%s" % ('#' + tag[0] if detailed else "", " <- current" if tag[1] in revtags else ""))
 
     # Print header
-    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url+('#'+str(repo.rev)[:12] if repo.rev else '') if detailed else revstr) or 'no revision'))
+    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url + ('#' + str(repo.rev)[:12] if repo.rev else '') if detailed else revstr) or 'no revision'))
 
     # Print list of tags
     rprefix = (prefix[:-3] + ('|  ' if prefix[-3] == '|' else '   ')) if recursive and prefix else ''
     rprefix += '| ' if recursive and len(repo.libs) > 1 else '  '
     if len(rels):
         for rel in rels:
-            print rprefix+'* '+rel
+            print rprefix + '* ' + rel
     else:
-        print rprefix+'No release tags detected'
+        print rprefix + 'No release tags detected'
 
     if recursive:
         for i, lib in enumerate(sorted(repo.libs, key=lambda l: l.path)):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LICENSE = open('LICENSE').read()
 
 setup(
     name="mbed-cli",
-    version="1.2.1",
+    version="1.2.2",
     description="ARM mbed command line tool for repositories version control, publishing and updating code from remotely hosted repositories (GitHub, GitLab and mbed.org), and invoking mbed OS own build system and export functions, among other operations",
     long_description=LONG_DESC,
     url='http://github.com/ARMmbed/mbed-cli',


### PR DESCRIPTION
This feature aims to enhance the workflow for the majority of developers who are looking for stable releases of a program or a library, where these stable revisions usually marked with a source control (Git/Hg) tag.

**Workflow**
1. Use `mbed import <url>` to import a program. Alternatively use `mbed new <path>` to create a program
2. Use `mbed ls` to list the structure of their program.
3. Use `mbed releases [-r]` to list available releases for a program or a library **<- this PR is aiming at improving this**
4. Use `mbed update <release tag>` to update to the release

Previously a developer had to fiddle with the relevant source control management (SCM) tool for their program or library. This is somewhat inconvenient as the command set between Git and Mercurial are very different (`hg tags` vs `git show-ref --tags --dereference`). Additionally the returned tags might be randomly formatted, which in a repository with large set of tags makes it hard to spot which are release/stable tags. `mbed releases` filters the displayed release tags based on commonly tag format (see https://git-scm.com/book/en/v2/Git-Basics-Tagging)

**How this works**

Listing the releases for the current program or library is done via `mbed releases`, e.g.

```
$ mbed import mbed-os-example-wifi
[SNIP]

$ mbed releases
mbed-os-example-wifi (#f9f04508a860, tags:mbed-os-5.6.5)
  * mbed-os-5.2.0 
  * mbed-os-5.2.1 
  * mbed-os-5.2.3 
  * mbed-os-5.3.0 
  * mbed-os-5.3.1 
  * mbed-os-5.3.2 
  * mbed-os-5.3.3 
  * mbed-os-5.3.4 
  * mbed-os-5.3.5 
  * mbed-os-5.3.6 
  * mbed-os-5.4 
  * mbed-os-5.4.1 
  * mbed-os-5.4.2 
  * mbed-os-5.4.3 
  * mbed-os-5.4.5 
  * mbed-os-5.5.1 
  * mbed-os-5.5.3 
  * mbed-os-5.5.5 
  * mbed-os-5.5.6 
  * mbed-os-5.5.7 
  * mbed-os-5.6.0 
  * mbed-os-5.6.1 
  * mbed-os-5.6.4 
  * mbed-os-5.6.5  <- current
```

Command switch `-a` is used to list release-hash pairs, e.g.
```
$ mbed releases -a
mbed-os-example-wifi (https://github.com/ARMmbed/mbed-os-example-wifi#f9f04508a860)
  * mbed-os-5.2.0 #23dfd8dbd33fdf17ed073ce29457ac722e200b08
  * mbed-os-5.2.1 #bc18a5c587e198d8e2b04f31c3314b25923ea1ff
  * mbed-os-5.2.3 #286f573a7a36a63c3c772c4fd28f84c545b54996
  * mbed-os-5.3.0 #57997dc40b71e91ab3214fdcb28c8cf2f0ca3d0e
  * mbed-os-5.3.1 #9cc04848da087cec959ae43caa2e3a3e390910f5
  * mbed-os-5.3.2 #8cb627404c04d3476989a2a0bdaf932e54f64a34
  * mbed-os-5.3.3 #27bfaf4a1f1d612c9fa5c04b1931559333576d78
  * mbed-os-5.3.4 #c8ea0d5489140fb0d13637b3b6c6715e4d0a3781
  * mbed-os-5.3.5 #6b4da1f52f3310c26b7fa71624cfc89134cbeb0c
  * mbed-os-5.3.6 #d3e0a72df157ab785f9f90130200bff2f32747b1
  * mbed-os-5.4 #3f6ee363545eb8a214056b1c5bf824223d5c7352
  * mbed-os-5.4.1 #a63841142aa9ed70f9c51b35325acbb58c24957d
  * mbed-os-5.4.2 #0b0f859c563bba23bef9591ddcb0711834026157
  * mbed-os-5.4.3 #83a1e84c8fe8a2ae333529b7971524a9ea5e8f32
  * mbed-os-5.4.5 #1c2d7cc3c4c4dd5969d2d73c3116c85622302fb3
  * mbed-os-5.5.1 #82638173e0feaf551df125fda0e19f85a8e608b1
  * mbed-os-5.5.3 #3fa3697d3184902c2eb348a59a2e7213c567bd17
  * mbed-os-5.5.5 #51649fb108cb7bbb43ba1b70acb005b3bbbeeba1
  * mbed-os-5.5.6 #0a3ffdeb12992b401b6b5ad8d1b09517cabef1be
  * mbed-os-5.5.7 #8f9c590da6a7e7d20dd4f98aea05539955dd9794
  * mbed-os-5.6.0 #1097ea0e420efc79d19ab9530292eea1d8ba7166
  * mbed-os-5.6.1 #908027f05043aed5aab4d9d4b18132eec1f32452
  * mbed-os-5.6.4 #8d539eef1f75b0a11f640c67da6d091d374c5792
  * mbed-os-5.6.5 #f9f04508a8605c258dc61f68a493461b29966588 <- current
```

While by default this command works for the current program or library, the `-r` switch enables recursive listing in a tree format similar to `mbed ls`, e.g.
```
$ mbed releases -r
mbed-os-example-wifi (#f9f04508a860, tags:mbed-os-5.6.5)
| * mbed-os-5.2.0 
| * mbed-os-5.2.1 
| * mbed-os-5.2.3 
| * mbed-os-5.3.0 
| * mbed-os-5.3.1 
| * mbed-os-5.3.2 
| * mbed-os-5.3.3 
| * mbed-os-5.3.4 
| * mbed-os-5.3.5 
| * mbed-os-5.3.6 
| * mbed-os-5.4 
| * mbed-os-5.4.1 
| * mbed-os-5.4.2 
| * mbed-os-5.4.3 
| * mbed-os-5.4.5 
| * mbed-os-5.5.1 
| * mbed-os-5.5.3 
| * mbed-os-5.5.5 
| * mbed-os-5.5.6 
| * mbed-os-5.5.7 
| * mbed-os-5.6.0 
| * mbed-os-5.6.1 
| * mbed-os-5.6.4 
| * mbed-os-5.6.5  <- current
|- esp8266-driver (#b0d79dad507d)
|    * v1.0 
|    * v1.1 
|    * v1.2 
|    * v1.3 
|    * v1.4 
|- mbed-os (#182bbd51bc8d, tags:latest, mbed-os-5.6.5)
|    * mbed-os-5.1.0 
|    * mbed-os-5.1.1 
|    * mbed-os-5.1.2 
|    * mbed-os-5.1.3 
|    * mbed-os-5.1.4 
|    * mbed-os-5.1.5 
|    * mbed-os-5.2.0 
|    * mbed-os-5.2.1 
|    * mbed-os-5.2.2 
|    * mbed-os-5.2.3 
|    * mbed-os-5.3.0 
|    * mbed-os-5.3.1 
|    * mbed-os-5.3.2 
|    * mbed-os-5.3.3 
|    * mbed-os-5.3.4 
|    * mbed-os-5.3.5 
|    * mbed-os-5.3.6 
|    * mbed-os-5.4.0 
|    * mbed-os-5.4.1 
|    * mbed-os-5.4.2 
|    * mbed-os-5.4.3 
|    * mbed-os-5.4.4 
|    * mbed-os-5.4.5 
|    * mbed-os-5.4.6 
|    * mbed-os-5.4.7 
|    * mbed-os-5.5.0 
|    * mbed-os-5.5.1 
|    * mbed-os-5.5.2 
|    * mbed-os-5.5.3 
|    * mbed-os-5.5.4 
|    * mbed-os-5.5.5 
|    * mbed-os-5.5.6 
|    * mbed-os-5.5.7 
|    * mbed-os-5.6.0 
|    * mbed-os-5.6.1 
|    * mbed-os-5.6.2 
|    * mbed-os-5.6.3 
|    * mbed-os-5.6.4 
|    * mbed-os-5.6.5  <- current
`- wifi-x-nucleo-idw01m1 (#5871f7011d7f)
     No release tags detected
```

Also, one can list unstable release tags, usually release candidates, alphas, betas, using the `-u` switch. This relaxes the release/tag name matcher to include a wider set of tags (see https://git-scm.com/book/en/v2/Git-Basics-Tagging again)
```
$ mbed releases -u
mbed-client (#31e5ce203cc0, tags:v3.0.0)
  * mbed-os-5.0-rc1 
  * mbed-os-5.0-rc2 
  * r0.5-rc4 
  ...
  * v2.2.0 
  * v2.2.1 
  * v3.0.0  <- current
```

Lastly, the implementation enhances `mbed ls` as well and makes it release/tag "aware". Here's an example:
```
$ mbed ls
mbed-os-example-client (#46555484a88d, tags:mbed-os-5.5.4)
|- easy-connect (#211cdf2bfa33)
|  |- atmel-rf-driver (#0ae76ce17ae5)
|  |- esp8266-driver (#ebc1fbd0b53a)
|  |  `- ESP8266/ATParser (#77734ee44a63)
|  |- mcr20a-rf-driver (#d5905fefa54c)
|  `- stm-spirit1-rf-driver (#09e4b9664de1)
|- mbed-client (#31e5ce203cc0, tags:v3.0.0)
|  |- mbed-client-c (#ecfa619e42b2, tags:v6.0.0)
|  |- mbed-client-classic (#4e66929607c3)
|  `- mbed-client-mbed-tls (#7e1b6d815038, tags:mbedCloudClient-R1.1, mbedCloudClient-R1.1-RC1)
|- mbed-os (#4c256f045961, tags:mbed-os-5.5.4, mbed_lib_rev148)
`- pal (#60ce64d5ec35)
```

**Documentation**
Documentation is included with this PR. Firstly `mbed releases` is briefly mentioned in the Importing/Creating section. Then it's more reviewed in detail in the "Update" section as a prerequisite for an update workflow (as per the description above).

@AnotherButler please review

**Tests**
Releases are listed recursively (using `mbed releases -r`) for both Git, Mercurial and Mbed 2/Classic repositories as part of the circle CI tests.

The feature was inspired by a conversation with @adbridge regarding releases process, release candidates, release tags, release XYZ, and end-developer workflows :)

CC @sg- @adbridge @MarceloSalazar 