### PR TITLE
Update CircleCI to run on Ubuntu 14.04 LTS instead of Ubutnu 12.04 LTS

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -83,4 +83,4 @@ dependencies:
         - mkdir .tests
         - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
         - sudo apt-get -y update
-        - sudo apt-get -y install gcc-arm-none-eabi=4.9.3.2015q3-1precise1
+        - sudo apt-get -y install gcc-arm-none-eabi=4.9.3.2015q3-1trusty1


### PR DESCRIPTION
Noticed when working on a past PR that I had to manually setup CircleCI to use Ubutnu 12.04 LTS, which is no longer being supported (see [link](https://circleci.com/blog/ubuntu-12-04-precise-build-image-end-of-life-warning/)).

PR updates only change needed to get CircleCI builds functional on 14.04.