### PR TITLE
UX: Tags/branches awareness

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -745,13 +745,18 @@ class Git(object):
         if not branch:
             # Default to "master" in detached mode
             branch = "master"
+        # Check if local branch exists. If not, then just carry on
         try:
-            # Check if remote branch exists
+            pquery([git_cmd, 'rev-parse', '%s' % branch])
+        except ProcessException:
+            return 0
+        # Check if remote branch exists. If not, then it's a new branch
+        try:
             if not pquery([git_cmd, 'rev-parse', '%s/%s' % (remote, branch)]):
                 return 1
         except ProcessException:
             return 1
-        # Check for outgoing commits for the same remote branch
+        # Check for outgoing commits for the same remote branch only if it exists locally and remotely
         return 1 if pquery([git_cmd, 'log', '%s/%s..%s' % (remote, branch, branch)]) else 0
 
     # Checks whether current working tree is detached

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1025,14 +1025,16 @@ class Repo(object):
 
         return "directory" if depth == 0 else ("program" if depth == 1 else "library")
 
-    def revtype(self, rev=None, ret_type=True, ret_rev=True):
+    def revtype(self, rev=None, ret_type=True, ret_rev=True, fmt=3):
         if rev is None or len(rev) == 0:
-            return ('latest' if ret_type else '') + (' revision in the current branch' if ret_rev else '')
+            output = ('latest' if fmt & 1 else '') + (' revision in the current branch' if fmt & 2 else '')
         elif re.match(r'^([a-fA-F0-9]{6,40})$', rev) or re.match(r'^([0-9]+)$', rev):
             revtags = self.scm.gettags(rev) if self.scm and rev else []
-            return ('rev ' if ret_type else '') + (('#' + rev[:12] + ((' (tag' + ('s' if len(revtags) > 1 else '') + ': ' + ', '.join(revtags[0:2]) + ')') if len(revtags) else '')) if ret_rev and rev else '')
+            output = ('rev ' if fmt & 1 else '') + (('#' + rev[:12] + ((' (tag' + ('s' if len(revtags) > 1 else '') + ': ' + ', '.join(revtags[0:2]) + ')') if len(revtags) else '')) if fmt & 2 and rev else '')
         else:
-            return ('branch/tag' if ret_type else '') + (' "'+rev+'"' if ret_rev else '')
+            output = ('branch/tag' if fmt & 1 else '') + (' "'+rev+'"' if fmt & 2 else '')
+
+        return re.sub(r' \(', ', ', re.sub(r'\)', '', output)) if fmt & 4 else output
 
     @classmethod
     def isurl(cls, url):
@@ -2178,7 +2180,7 @@ def sync(recursive=True, keep_refs=False, top=True):
 def list_(detailed=False, prefix='', p_path=None, ignore=False):
     repo = Repo.fromrepo()
 
-    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url + ('#' + str(repo.rev)[:12] if repo.rev else '') if detailed else re.sub(r' \(', ', ', re.sub(r'\)', '', repo.revtype(repo.rev, False)))) or 'no revision'))
+    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url + ('#' + str(repo.rev)[:12] if repo.rev else '') if detailed else repo.revtype(repo.rev, fmt=6)) or 'no revision'))
 
     for i, lib in enumerate(sorted(repo.libs, key=lambda l: l.path)):
         nprefix = (prefix[:-3] + ('|  ' if prefix[-3] == '|' else '   ')) if prefix else ''
@@ -2210,7 +2212,7 @@ def releases_(detailed=False, unstable=False, recursive=False, prefix='', p_path
             rels.append(tag[1] + " %s%s" % ('#' + tag[0] if detailed else "", " <- current" if tag[1] in revtags else ""))
 
     # Print header
-    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url + ('#' + str(repo.rev)[:12] if repo.rev else '') if detailed else re.sub(r' \(', ', ', re.sub(r'\)', '', repo.revtype(repo.rev, False)))) or 'no revision'))
+    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url + ('#' + str(repo.rev)[:12] if repo.rev else '') if detailed else repo.revtype(repo.rev, fmt=6)) or 'no revision'))
 
     # Print list of tags
     rprefix = (prefix[:-3] + ('|  ' if prefix[-3] == '|' else '   ')) if recursive and prefix else ''

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -538,7 +538,7 @@ class Hg(object):
         refs = pquery([hg_cmd, 'tags']).strip().splitlines() or []
         for ref in refs:
             m = re.match(r'^(.+?)\s+(\d+)\:([a-f0-9]+)$', ref)
-            if m and m.group(1) != 'tips':
+            if m:
                 tags.append([m.group(3), m.group(1)])
         return tags
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2178,7 +2178,7 @@ def sync(recursive=True, keep_refs=False, top=True):
 def list_(detailed=False, prefix='', p_path=None, ignore=False):
     repo = Repo.fromrepo()
 
-    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url + ('#' + str(repo.rev)[:12] if repo.rev else '') if detailed else repo.revtype(repo.rev, False)) or 'no revision'))
+    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url + ('#' + str(repo.rev)[:12] if repo.rev else '') if detailed else re.sub(r' \(', ', ', re.sub(r'\)', '', repo.revtype(repo.rev, False)))) or 'no revision'))
 
     for i, lib in enumerate(sorted(repo.libs, key=lambda l: l.path)):
         nprefix = (prefix[:-3] + ('|  ' if prefix[-3] == '|' else '   ')) if prefix else ''
@@ -2210,7 +2210,7 @@ def releases_(detailed=False, unstable=False, recursive=False, prefix='', p_path
             rels.append(tag[1] + " %s%s" % ('#' + tag[0] if detailed else "", " <- current" if tag[1] in revtags else ""))
 
     # Print header
-    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url + ('#' + str(repo.rev)[:12] if repo.rev else '') if detailed else repo.revtype(repo.rev, False)) or 'no revision'))
+    print "%s (%s)" % (prefix + (relpath(p_path, repo.path) if p_path else repo.name), ((repo.url + ('#' + str(repo.rev)[:12] if repo.rev else '') if detailed else re.sub(r' \(', ', ', re.sub(r'\)', '', repo.revtype(repo.rev, False)))) or 'no revision'))
 
     # Print list of tags
     rprefix = (prefix[:-3] + ('|  ' if prefix[-3] == '|' else '   ')) if recursive and prefix else ''


### PR DESCRIPTION
**This PR fixes/adds:**
* Tags handling in Mercurial/hg
* Tags/releases awareness across various mbed CLI commands.
* The Git.outgoing() routine will now correctly check if a local branch exists. Previously mbed CLI was throwing an error when trying to check outgoing changes by comparing remote master branch and non-existent local master branch

**Details/Logs**

Mercurial tags are now correctly displayed
```
/tmp/hg-test]$ mbed ls
hg-test (#38124d242060)
`- mbed-os (#dc6cb4f1a87a, tag: tip)
   |- core (#2f7f0a7fc6b3)
   |  |- mbed-rtos (#bdd541595fc5)
   |  |- mbed-uvisor (#af27c87db9c2)
   |  `- mbedtls (#dee5972f341f)
   |- hal (#f1c94b98286f)
   |  `- targets/TARGET_Freescale (#a35ebe05b3bd)
   |     |- TARGET_KPSDK_MCUS (#e4d670b91a9a, tag: tip)
   |     `- TARGET_MCU_K64F (#c5e2f793b59a, tag: tip)
   |- net (#1ff180f69e71, tag: tip)
   |  |- ESP8266Interface (#c0808849cb89, tag: tip)
   |  |  `- ESP8266 (#c18644e0e0dd)
   |  |     `- ATParser (#6b8190f55d83)
   |  |        `- BufferedSerial (#a0d37088b405, tag: tip)
   |  |           `- Buffer (#89564915f2a7, tag: tip)
   |  |- LWIPInterface (#1efb0d91c223)
   |  |  |- lwip (#08f08bfc3f3d, tag: tip)
   |  |  |- lwip-eth (#4380f0749039)
   |  |  `- lwip-sys (#12e78a2462d0)
   |  |- NetworkSocketAPI (#6cfd38609828)
   |  |  `- DnsQuery (#18a6b52be896)
   |  |- mbed-client (#e36098b177a4, tag: tip)
   |  |- mbed-client-c (#5d91b0f5038c, tag: tip)
   |  |- mbed-client-classic (#723bfe4dd180, tag: tip)
   |  |- mbed-client-mbedtls (#80a66815c791, tag: tip)
   |  |- mbed-trace (#506ad37c6bd7, tag: tip)
   |  `- nanostack-libservice (#a87c5afee2a6, tag: tip)
   `- tools (#ca00ce2bd4be)
```

Also `mbed update` and other commands will now show revision hashes and associated tags/releases (if any).
```
/tmp/mbed-os-example-client:$ mbed update mbed-os-5.6.1
[mbed] Updating program "mbed-os-example-client" to branch/tag "mbed-os-5.6.1"
[mbed] Updating library "easy-connect" to rev #bf821b0695cc
[mbed] Removing library "easy-connect/wifi-x-nucleo-idw01m1" (obsolete)
[mbed] Updating library "easy-connect/atmel-rf-driver" to rev #3cc6010188c0
[mbed] Updating library "easy-connect/esp8266-driver" to rev #fdb44a4bedbb
[mbed] Adding library "easy-connect/esp8266-driver/ESP8266/ATParser" from "https://github.com/ARMmbed/ATParser" at rev #a2cb09990f11
[mbed] Updating library "easy-connect/mcr20a-rf-driver" to rev #9aac10474702
[mbed] Updating library "easy-connect/stm-spirit1-rf-driver" to rev #bee61bbe6807
[mbed] Updating library "mbed-client" to rev #31e5ce203cc0 (tag: v3.0.0)
[mbed] Updating library "mbed-client/mbed-client-c" to rev #ecfa619e42b2 (tag: v6.0.0)
[mbed] Updating library "mbed-client/mbed-client-classic" to rev #4e66929607c3
[mbed] Updating library "mbed-client/mbed-client-mbed-tls" to rev #7e1b6d815038 (tags: mbedCloudClient-R1.1, mbedCloudClient-R1.1-RC1)
[mbed] Updating library "mbed-os" to rev #cc7556a92fb9 (tags: mbed-os-5.6.1, mbed_lib_rev152)
[mbed] Updating library "pal" to rev #60ce64d5ec35
```

