### PR TITLE
UX: Add progress bar for both Git and Mercurial when using non-verbose mode

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -180,19 +180,12 @@ def progress():
 def show_progress(title, percent, max_width=80):
     percent = round(float(percent), 2)
     show_percent = '%.2f' % percent
-    line = str(title) + ' |'
-    bwidth = max_width - len(str(title)) - len(show_percent) - 6
-    for i in range(0, bwidth):
-        line += '#' if i <= (percent / 100 * bwidth) else '-'
-    line += '| ' + show_percent + '%'
-    sys.stdout.write(line+'\r')
+    bwidth = max_width - len(str(title)) - len(show_percent) - 6 # 6 equals the spaces and paddings between title, progress bar and percentage
+    sys.stdout.write('%s |%s%s| %s%%\r' % (str(title), '#' * int(percent * bwidth // 100), '-' * (bwidth - int(percent * bwidth // 100)), show_percent))
     sys.stdout.flush()
 
 def hide_progress(max_width=80):
-    line = ''
-    for i in range(0, max_width):
-        line += ' '
-    sys.stdout.write("\r%s\r" % line)
+    sys.stdout.write("\r%s\r" % (' ' * max_width))
 
 # Process execution
 class ProcessException(Exception):
@@ -241,7 +234,7 @@ def pquery(command, output_callback=None, stdin=None, **kwargs):
             else:
                 break
 
-    stdout, stderr = proc.communicate(stdin)
+    stdout, _ = proc.communicate(stdin)
 
     if very_verbose:
         log(str(stdout).strip()+"\n")

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -451,9 +451,9 @@ class Hg(object):
         m = re.match(r'(\w+).+?\s+(\d+)/(\d+)\s+.*?', line)
         if m:
             if m.group(1) == "manifests":
-                show_progress('Downloading', (float(m.group(2)) / float(m.group(3))) * 20, 80)
+                show_progress('Downloading', (float(m.group(2)) / float(m.group(3))) * 20)
             if m.group(1) == "files":
-                show_progress('Downloading', (float(m.group(2)) / float(m.group(3))) * 100, 80)
+                show_progress('Downloading', (float(m.group(2)) / float(m.group(3))) * 100)
 
     def add(dest):
         info("Adding reference \"%s\"" % dest)
@@ -681,9 +681,16 @@ class Git(object):
             hide_progress()
 
     def clone_progress(line, sep):
-        m = re.match(r'Receiving objects\:\s*(\d+)% \((\d+)/(\d+)\)', line)
+        m = re.match(r'([\w :]+)\:\s*(\d+)% \((\d+)/(\d+)\)', line)
         if m:
-            show_progress('Downloading', (float(m.group(2)) / float(m.group(3))) * 100, 80)
+            if m.group(1) == "remote: Compressing objects" and int(m.group(4)) > 10:
+                show_progress('Preparing', (float(m.group(3)) / float(m.group(4))) * 100)
+            if m.group(1) == "Receiving objects":
+                show_progress('Downloading', (float(m.group(3)) / float(m.group(4))) * 80)
+            if m.group(1) == "Resolving deltas":
+                show_progress('Downloading', (float(m.group(3)) / float(m.group(4))) * 10 + 80)
+            if m.group(1) == "Checking out files":
+                show_progress('Downloading', (float(m.group(3)) / float(m.group(4))) * 10 + 90)
 
     def add(dest):
         info("Adding reference "+dest)

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -187,10 +187,12 @@ def show_progress(title, percent, max_width=80):
     line += '| ' + show_percent + '%'
     sys.stdout.write(line+'\r')
     sys.stdout.flush()
-    sys.stdout.write('\b')
 
-def hide_progress():
-    sys.stdout.write("\033[K\r\b")
+def hide_progress(max_width=80):
+    line = ''
+    for i in range(0, max_width):
+        line += ' '
+    sys.stdout.write("\r%s\r" % line)
 
 # Process execution
 class ProcessException(Exception):


### PR DESCRIPTION
**This PR adds**
* Progress bar for both Git and Mercurial when cloning

The progress bar is only visible when mbed CLI is in non-verbose mode (no `-v` or `-vv`).

**Git example:**
```
/tmp:$ mbed import mbed-os-example-client
[mbed] Importing program "mbed-os-example-client" from "https://github.com/ARMmbed/mbed-os-example-client" at latest revision in the current branch
[mbed] Adding library "easy-connect" from "https://github.com/ARMmbed/easy-connect" at rev #6af200df4817
[mbed] Adding library "easy-connect/atmel-rf-driver" from "https://github.com/ARMmbed/atmel-rf-driver" at rev #2cd9abba3e37
[mbed] Adding library "easy-connect/esp8266-driver" from "https://github.com/ARMmbed/esp8266-driver" at rev #b0d79dad507d
[mbed] Adding library "easy-connect/mcr20a-rf-driver" from "https://github.com/ARMmbed/mcr20a-rf-driver" at rev #9aac10474702
[mbed] Adding library "easy-connect/stm-spirit1-rf-driver" from "https://github.com/ARMmbed/stm-spirit1-rf-driver" at rev #0ff4ca7537f0
[mbed] Adding library "easy-connect/wifi-x-nucleo-idw01m1" from "https://github.com/ARMmbed/wifi-x-nucleo-idw01m1" at rev #537b01c4a053
[mbed] Adding library "mbed-client" from "https://github.com/ARMmbed/mbed-client" at rev #ea04c5de7822
[mbed] Adding library "mbed-client/mbed-client-c" from "https://github.com/ARMmbed/mbed-client-c" at rev #ecfa619e42b2
[mbed] Adding library "mbed-client/mbed-client-classic" from "https://github.com/ARMmbed/mbed-client-classic" at rev #4e66929607c3
[mbed] Adding library "mbed-client/mbed-client-mbed-tls" from "https://github.com/ARMmbed/mbed-client-mbed-tls" at rev #7e1b6d815038
[mbed] Adding library "mbed-os" from "https://github.com/ARMmbed/mbed-os" at rev #8b54959f5bca
Downloading |##########------------------------------------------------| 16.17%
```

**Hg example:**
```
/tmp/1:$ mbed import https://os.mbed.com/users/mbed_official/code/mbed-dev
[mbed] Importing program "mbed-dev" from "https://os.mbed.com/users/mbed_official/code/mbed-dev" at latest revision in the current branch
Downloading |######################------------------------------------| 36.75%
```

Note that with Mercurial/Hg the progress bar appears late because of the progress reported late by Mercurial.

**Backwards compatbility**
This PR is fully backwards compatible

**Documentation**
No documentation is needed