### PR TITLE
Fix printing of detected targets for `mbed detect`

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2578,7 +2578,7 @@ def detect():
         env = program.get_env()
 
         try:
-            pquery([python_cmd, '-u', os.path.join(tools_dir, 'detect_targets.py')]
+            popen([python_cmd, '-u', os.path.join(tools_dir, 'detect_targets.py')]
                   + args,
                   env=env)
         except ProcessException as e:


### PR DESCRIPTION
As reported in #597 

cc @MarceloSalazar can you test?