### PR TITLE
Use python that executes mbed CLI to call pip

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1449,7 +1449,7 @@ class Program(object):
                 if missing and install_requirements:
                     try:
                         action("Auto-installing missing Python modules...")
-                        pquery(['pip', 'install', '-q', '-r', os.path.join(req_path, req_file)])
+                        pquery([python_cmd, '-m', 'pip', 'install', '-q', '-r', os.path.join(req_path, req_file)])
                         missing = []
                     except ProcessException:
                         warning("Unable to auto-install required Python modules.")


### PR DESCRIPTION
This PR tries to address (part of) the feedback in #604, that pip is called in insecure manner, e.g. it's not the same as the python executing mbed CLI.

Tested on Windows and Mac OS in non-venv environment. Would be helpful if someone could test it against venv (cc @sg-)