### PR TITLE
Update mbed-cli to allow different configured path for mbed-os

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1384,6 +1384,8 @@ class Program(object):
 
     # Gets mbed OS dir (unified)
     def get_os_dir(self):
+        if self.get_cfg('MBED_OS_DIR', None) is not None:
+            return self.get_cfg('MBED_OS_DIR')
         if os.path.isdir(os.path.join(self.path, 'mbed-os')):
             return os.path.join(self.path, 'mbed-os')
         elif self.name == 'mbed-os':


### PR DESCRIPTION
In not every project structure it makes sense to have the mbed-os directory at the root of your project structure.
This change allows you to configure a custom path for the mbed-os directory in your .mbed configuration.


In our case, our project calls for multiple firmware builds. But we do not want checkout mbed-os per firmware. mbed-cli allows this with the ```--source``` parameter, however, it does require that mbed-os is in the root of the project.

With this change we can setup mbed-os in a better subfolder to allow for a better project structure:
```
extlibs/mbed-os
module/mobuleA
module/moduleB
project/project1
project/project2
```
And compile those with:
```
mbed-cli config MBED_OS_DIR extlibs/mbed-os/
mbed-cli compile -f --profile release --source project/project1 --source module --source extlibs/mbed-os --build BUILD/project1
mbed-cli compile -f --profile release --source project/project2 --source module --source extlibs/mbed-os --build BUILD/project2
```
