### PR TITLE
New feature: mbed cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ Use these with caution because your uncommitted changes and unpublished librarie
 
 ## Repository caching
 
-To minimize traffic and reduce import times, by default Mbed CLI would cache repositories by storing their indexes under the Mbed CLI user config folder - typically `~/.mbed/mbed-cache/` on UNIX systems, or `%userprofile%/.mbed/mbed-cache/` on Windows systems. Compared to a fully checked out repository, indexes are significantly smaller in size and number of files, and contain the whole revision history of that repository. This allows Mbed CLI to quickly create copies of previously downloaded repository indexes and pull/fetch only the latest changes from the remote repositories, therefore dramatically reducing network traffic and download times, especially for big repositories like `mbed-os`.
+To minimize traffic and reduce import times, by default Mbed CLI caches repositories by storing their indexes under the Mbed CLI user config folder - typically `~/.mbed/mbed-cache/` on UNIX systems, or `%userprofile%/.mbed/mbed-cache/` on Windows systems. Compared to a fully checked out repository, indexes are significantly smaller in size and number of files, and contain the whole revision history of that repository. This allows Mbed CLI to quickly create copies of previously downloaded repository indexes and pull/fetch only the latest changes from the remote repositories, therefore dramatically reducing network traffic and download times, especially for big repositories like `mbed-os`.
 
 You can manage the Mbed CLI caching behavior with the following sub-commands:
 
@@ -861,18 +861,18 @@ You can manage the Mbed CLI caching behavior with the following sub-commands:
 mbed cache [on|off|dir <path>|ls|purge|-h|--help]
 ```
 
- * `on` - Turn repository caching on. Will use either the default or the user specified cache directory.
+ * `on` - Turn repository caching on. This will either use the user specified cache directory or the default one. See "dir".
  * `off` - Turn repository caching off. Note that this doesn't purge cached repositories. See "purge".
  * `dir` - Set cache directory. Set to "default" to let mbed CLI determine the cache directory location. Typically this is `~/.mbed/mbed-cache/` on UNIX systems, or `%%userprofile%%/.mbed/mbed-cache/` on Windows systems.
  * `ls` - List cached repositories and their size.
  * `purge` - Purge cached repositories. Note that this doesn't turn caching off.
  * `-h` or `--help` - Print cache command options.
 
-If no sub-command is specified to `mbed cache`, then mbed CLI would print the current cache setting (ENABLED or DISABLED) and the path to the local cache directory.
+If no sub-command is specified to `mbed cache`, mbed CLI prints the current cache setting (ENABLED or DISABLED) and the path to the local cache directory.
 
-For safety reasons, Mbed CLI will always use `mbed-cache` subfolder to a user specified location. This ensure that no user files will deleted during `purge` even if the user has specified root/system folder as a cache location (e.g. `mbed cache dir /` or `mbed cache dir C:\`).
+For safety reasons, Mbed CLI uses `mbed-cache` subfolder to a user specified location. This ensure that no user files will deleted during `purge` even if the user has specified root/system folder as a cache location (e.g. `mbed cache dir /` or `mbed cache dir C:\`).
 
-**Security notice**: It's generally recommended to use cache location inside your profile home directory. If you use cache location outside your user home/profile, then other system users might be able to access the repository cache and therefore the data of the cached repositories
+**Security notice**: If you use cache location outside your user home/profile directory, then other system users might be able to access the repository cache and therefore the data of the cached repositories.
 
 
 ## Mbed CLI configuration

--- a/README.md
+++ b/README.md
@@ -898,7 +898,6 @@ Here is a list of configuration settings and their defaults:
  * `ARM_PATH`, `ARMC6_PATH`, `GCC_ARM_PATH`, `IAR_PATH` - defines the path to Arm Compiler 5 and 6, GCC Arm and IAR Workbench toolchains. Default: none.
  * `protocol` - defines the default protocol used for importing or cloning of programs and libraries. The possible values are `https`, `http` and `ssh`. Use `ssh` if you have generated and registered SSH keys (Public Key Authentication) with a service such as GitHub, GitLab, Bitbucket and so on. Read more about SSH keys [here](https://help.github.com/articles/generating-an-ssh-key/). Default: `https`.
  * `depth` - defines the *clone* depth for importing or cloning and applies only to *Git* repositories. Note that though this option may improve cloning speed, it may also prevent you from correctly checking out a dependency tree when the reference revision hash is older than the clone depth. Read more about shallow clones [here](https://git-scm.com/docs/git-clone). Default: none.
- * `cache` - defines the local path that stores small copies of the imported or cloned repositories, and Mbed CLI uses it to minimize traffic and speed up future imports of the same repositories. Use `off` or `disabled` to turn off repository caching. Use `none` to turn caching off. Default: on (in ~/.mbed/mbed-cache/).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -863,7 +863,7 @@ mbed cache [on|off|dir <path>|ls|purge|-h|--help]
 
  * `on` - Turn repository caching on. Will use either the default or the user specified cache directory.
  * `off` - Turn repository caching off. Note that this doesn't purge cached repositories. See "purge".
- * 'dir' - Set cache directory. Set to "default" to let mbed CLI determine the cache directory location. Typically this is `~/.mbed/mbed-cache/` on UNIX systems, or `%%userprofile%%/.mbed/mbed-cache/` on Windows systems.
+ * `dir` - Set cache directory. Set to "default" to let mbed CLI determine the cache directory location. Typically this is `~/.mbed/mbed-cache/` on UNIX systems, or `%%userprofile%%/.mbed/mbed-cache/` on Windows systems.
  * `ls` - List cached repositories and their size.
  * `purge` - Purge cached repositories. Note that this doesn't turn caching off.
  * `-h` or `--help` - Print cache command options.

--- a/README.md
+++ b/README.md
@@ -851,6 +851,30 @@ You can combine the options of the Mbed update command for the following scenari
 
 Use these with caution because your uncommitted changes and unpublished libraries cannot be restored.
 
+## Repository caching
+
+To minimize traffic and reduce import times, by default Mbed CLI would cache repositories by storing their indexes under the Mbed CLI user config folder - typically `~/.mbed/mbed-cache/` on UNIX systems, or `%userprofile%/.mbed/mbed-cache/` on Windows systems. Compared to a fully checked out repository, indexes are significantly smaller in size and number of files, and contain the whole revision history of that repository. This allows Mbed CLI to quickly create copies of previously downloaded repository indexes and pull/fetch only the latest changes from the remote repositories, therefore dramatically reducing network traffic and download times, especially for big repositories like `mbed-os`.
+
+You can manage the Mbed CLI caching behavior with the following sub-commands:
+
+```
+mbed cache [on|off|dir <path>|ls|purge|-h|--help]
+```
+
+ * `on` - Turn repository caching on. Will use either the default or the user specified cache directory.
+ * `off` - Turn repository caching off. Note that this doesn't purge cached repositories. See "purge".
+ * 'dir' - Set cache directory. Set to "default" to let mbed CLI determine the cache directory location. Typically this is `~/.mbed/mbed-cache/` on UNIX systems, or `%%userprofile%%/.mbed/mbed-cache/` on Windows systems.
+ * `ls` - List cached repositories and their size.
+ * `purge` - Purge cached repositories. Note that this doesn't turn caching off.
+ * `-h` or `--help` - Print cache command options.
+
+If no sub-command is specified to `mbed cache`, then mbed CLI would print the current cache setting (ENABLED or DISABLED) and the path to the local cache directory.
+
+For safety reasons, Mbed CLI will always use `mbed-cache` subfolder to a user specified location. This ensure that no user files will deleted during `purge` even if the user has specified root/system folder as a cache location (e.g. `mbed cache dir /` or `mbed cache dir C:\`).
+
+**Security notice: It's generally recommended to user cache location inside your own home directory. If you use cache location outside your user home/profile, then other system users might be able to access the repository cache and therefore the data of the cached repositories**
+
+
 ## Mbed CLI configuration
 
 You can streamline many options in Mbed CLI with global and local configuration.
@@ -874,7 +898,7 @@ Here is a list of configuration settings and their defaults:
  * `ARM_PATH`, `ARMC6_PATH`, `GCC_ARM_PATH`, `IAR_PATH` - defines the path to Arm Compiler 5 and 6, GCC Arm and IAR Workbench toolchains. Default: none.
  * `protocol` - defines the default protocol used for importing or cloning of programs and libraries. The possible values are `https`, `http` and `ssh`. Use `ssh` if you have generated and registered SSH keys (Public Key Authentication) with a service such as GitHub, GitLab, Bitbucket and so on. Read more about SSH keys [here](https://help.github.com/articles/generating-an-ssh-key/). Default: `https`.
  * `depth` - defines the *clone* depth for importing or cloning and applies only to *Git* repositories. Note that though this option may improve cloning speed, it may also prevent you from correctly checking out a dependency tree when the reference revision hash is older than the clone depth. Read more about shallow clones [here](https://git-scm.com/docs/git-clone). Default: none.
- * `cache` - defines the local path that stores small copies of the imported or cloned repositories, and Mbed CLI uses it to minimize traffic and speed up future imports of the same repositories. Use `on` or `enabled` to turn on caching in the system temp path. Use `none` to turn caching off. Default: none (disabled).
+ * `cache` - defines the local path that stores small copies of the imported or cloned repositories, and Mbed CLI uses it to minimize traffic and speed up future imports of the same repositories. Use `off` or `disabled` to turn off repository caching. Use `none` to turn caching off. Default: on (in ~/.mbed/mbed-cache/).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -853,27 +853,26 @@ Use these with caution because your uncommitted changes and unpublished librarie
 
 ## Repository caching
 
-To minimize traffic and reduce import times, by default Mbed CLI caches repositories by storing their indexes under the Mbed CLI user config folder - typically `~/.mbed/mbed-cache/` on UNIX systems, or `%userprofile%/.mbed/mbed-cache/` on Windows systems. Compared to a fully checked out repository, indexes are significantly smaller in size and number of files, and contain the whole revision history of that repository. This allows Mbed CLI to quickly create copies of previously downloaded repository indexes and pull/fetch only the latest changes from the remote repositories, therefore dramatically reducing network traffic and download times, especially for big repositories like `mbed-os`.
+To minimize traffic and reduce import times, by default Mbed CLI caches repositories by storing their indexes under the Mbed CLI user config folder - typically `~/.mbed/mbed-cache/` on UNIX systems, or `%userprofile%/.mbed/mbed-cache/` on Windows systems. Compared to a fully checked out repository, indexes are significantly smaller in size and number of files and contain the whole revision history of that repository. This allows Mbed CLI to quickly create copies of previously downloaded repository indexes and pull/fetch only the latest changes from the remote repositories, therefore dramatically reducing network traffic and download times, especially for big repositories such as `mbed-os`.
 
-You can manage the Mbed CLI caching behavior with the following sub-commands:
+You can manage the Mbed CLI caching behavior with the following subcommands:
 
 ```
 mbed cache [on|off|dir <path>|ls|purge|-h|--help]
 ```
 
- * `on` - Turn repository caching on. This will either use the user specified cache directory or the default one. See "dir".
+ * `on` - Turn repository caching on. This uses either the user specified cache directory or the default one. See "dir".
  * `off` - Turn repository caching off. Note that this doesn't purge cached repositories. See "purge".
- * `dir` - Set cache directory. Set to "default" to let mbed CLI determine the cache directory location. Typically this is `~/.mbed/mbed-cache/` on UNIX systems, or `%%userprofile%%/.mbed/mbed-cache/` on Windows systems.
+ * `dir` - Set cache directory. Set to "default" to let Mbed CLI determine the cache directory location. Typically, this is `~/.mbed/mbed-cache/` on UNIX systems, or `%%userprofile%%/.mbed/mbed-cache/` on Windows systems.
  * `ls` - List cached repositories and their size.
  * `purge` - Purge cached repositories. Note that this doesn't turn caching off.
  * `-h` or `--help` - Print cache command options.
 
-If no sub-command is specified to `mbed cache`, mbed CLI prints the current cache setting (ENABLED or DISABLED) and the path to the local cache directory.
+If no subcommand is specified to `mbed cache`, Mbed CLI prints the current cache setting (ENABLED or DISABLED) and the path to the local cache directory.
 
-For safety reasons, Mbed CLI uses `mbed-cache` subfolder to a user specified location. This ensure that no user files will deleted during `purge` even if the user has specified root/system folder as a cache location (e.g. `mbed cache dir /` or `mbed cache dir C:\`).
+For safety reasons, Mbed CLI uses the `mbed-cache` subfolder to a user specified location. This ensures that no user files are deleted during `purge` even if the user has specified root/system folder as a cache location (for example, `mbed cache dir /` or `mbed cache dir C:\`).
 
 **Security notice**: If you use cache location outside your user home/profile directory, then other system users might be able to access the repository cache and therefore the data of the cached repositories.
-
 
 ## Mbed CLI configuration
 

--- a/README.md
+++ b/README.md
@@ -872,7 +872,7 @@ If no sub-command is specified to `mbed cache`, then mbed CLI would print the cu
 
 For safety reasons, Mbed CLI will always use `mbed-cache` subfolder to a user specified location. This ensure that no user files will deleted during `purge` even if the user has specified root/system folder as a cache location (e.g. `mbed cache dir /` or `mbed cache dir C:\`).
 
-**Security notice: It's generally recommended to user cache location inside your own home directory. If you use cache location outside your user home/profile, then other system users might be able to access the repository cache and therefore the data of the cached repositories**
+**Security notice**: It's generally recommended to use cache location inside your profile home directory. If you use cache location outside your user home/profile, then other system users might be able to access the repository cache and therefore the data of the cached repositories
 
 
 ## Mbed CLI configuration

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2782,7 +2782,7 @@ def toolchain_(name=None, global_cfg=False, supported=False):
 @subcommand('cache',
     dict(name='on', nargs='?', help='Turn repository caching on. Will use either the default or the user specified cache directory.'),
     dict(name='off', nargs='?', help='Turn repository caching off. Note that this doesn\'t purge cached repositories. See "purge".'),
-    dict(name='dir', nargs='?', help='Set cache directory. Set to "default" to let mbed CLI determine the cache directory location. Typically this is "~/.mbed/mbed-cache/" on UNIX, or "%%userprofile%%/.mbed/mbed-cache/" on Windows.'),
+    dict(name='dir', nargs='?', help='Set cache directory. Set to "default" to let mbed CLI determine the cache directory location (%s/mbed-cache/).' % Global().path),
     dict(name='ls', nargs='?', help='List cached repositories and their sizes.'),
     dict(name='purge', nargs='?', help='Purge cached repositories. Note that this doesn\'t turn caching off'),
     help='Repository cache management\n\n',
@@ -2844,8 +2844,9 @@ def cache_(on=False, off=False, dir=None, ls=False, purge=False, global_cfg=Fals
         action("Purge complete!")
     elif cmd == "false":
         action("Repository cache is %s." % str(cfg['cache']).upper())
-        action("Cache location \"%s\"" % cfg['cache_base'])
+        action("Cache location \"%s\"" % cfg['cache_dir'])
     else:
+        print cmd
         error("Invalid cache command. Please see \"mbed cache --help\" for valid commands.")
 
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1711,12 +1711,12 @@ class Cfg(object):
 
     # Get cache configuration
     def cache(self):
-        cache_cfg = self.get('CACHE', None)
+        cache_cfg = self.get('CACHE', 'enabled')
         cache_val = 'enabled' if cache_repositories and cache_cfg and cache_cfg != 'none' and cache_cfg != 'off' and cache_cfg != 'disabled' else 'disabled'
 
         cache_dir_cfg = self.get('CACHE_DIR', None)
         loc = cache_dir_cfg if cache_dir_cfg != 'default' else (cache_cfg if (cache_cfg and cache_cfg != 'on' and cache_cfg != 'off' and cache_cfg != 'none' and cache_cfg != 'enabled' and cache_cfg != 'disabled') else None)
-        cache_base = loc or tempfile.gettempdir()
+        cache_base = loc or Global().path
         return {'cache': cache_val, 'cache_base': cache_base, 'cache_dir': os.path.join(cache_base, 'mbed-cache')}
 
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2846,7 +2846,6 @@ def cache_(on=False, off=False, dir=None, ls=False, purge=False, global_cfg=Fals
         action("Repository cache is %s." % str(cfg['cache']).upper())
         action("Cache location \"%s\"" % cfg['cache_base'])
     else:
-        print cmd
         error("Invalid cache command. Please see \"mbed cache --help\" for valid commands.")
 
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2811,8 +2811,8 @@ def cache_(on=False, off=False, ls=False, purge=False, cache_dir=None, global_cf
     if cmd == 'off' or cmd == 'on':
         g.set_cfg('CACHE', 'enabled' if cmd == 'on' else 'disabled')
         cfg = g.cache_cfg()
-        action('Repository cache is now %s.' % str(cfg['cache']).upper())
-        action('Cache location \"%s\"' % cfg['cache_dir'])
+        action("Repository cache is now %s." % str(cfg['cache']).upper())
+        action("Cache location \"%s\"" % cfg['cache_dir'])
     elif cmd == 'ls':
         def get_size_(path):
             size = 0
@@ -2821,7 +2821,7 @@ def cache_(on=False, off=False, ls=False, purge=False, cache_dir=None, global_cf
                     size += os.path.getsize(os.path.join(dirpath, f))
             return size
 
-        action('Listing cached repositories in \"%s\"' % cfg['cache_base'])
+        action("Listing cached repositories in \"%s\"" % cfg['cache_base'])
         repos = []
         total_size = 0
         for dirpath, dirs, files in os.walk(cfg['cache_dir']):
@@ -2831,20 +2831,21 @@ def cache_(on=False, off=False, ls=False, purge=False, cache_dir=None, global_cf
                 url = repo.url
                 size = get_size_(repo.path)
                 total_size += size
-                log('* %s %s\n' % ('{:60}'.format(url), sizeof_fmt(size).rjust(8)))
+                log("* %s %s\n" % ('{:64}'.format(url), sizeof_fmt(size).rjust(8)))
                 for d in dirs:
                     dirs.remove(d)
-        log('%s %s\n' % ('{:62}'.format('Total:'), sizeof_fmt(total_size).rjust(8)))
+        log("---------------------------------------------------------------------------\n")
+        log("%s %s\n" % ('{:66}'.format('Total size:'), sizeof_fmt(total_size).rjust(8)))
 
     elif cmd == 'purge':
-        action('Purging cached repositories in \"%s\"' % cfg['cache_base'])
+        action("Purging cached repositories in \"%s\"..." % cfg['cache_base'])
         if os.path.isdir(cfg['cache_dir']):
             rmtree_readonly(cfg['cache_dir'])
 
-        action('Purge complete')
+        action("Purge complete!")
     else:
-        action('Repository cache is %s.' % str(cfg['cache']).upper())
-        action('Cache location \"%s\"' % cfg['cache_base'])
+        action("Repository cache is %s." % str(cfg['cache']).upper())
+        action("Cache location \"%s\"" % cfg['cache_base'])
 
 
 @subcommand('help',

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -255,6 +255,12 @@ def rmtree_readonly(directory):
             func(path)
         shutil.rmtree(directory, onerror=remove_readonly)
 
+def sizeof_fmt(num, suffix='B'):
+    for unit in ['','K','M','G','T','P','E','Z']:
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yi', suffix)
 
 # Directory navigation
 @contextlib.contextmanager
@@ -2801,21 +2807,42 @@ def cache_(on=False, off=False, ls=False, purge=False, cache_dir=None, global_cf
         g.set_cfg('CACHE_DIR', cache_dir)
         action('Repository cache location set to \"%s\"' % cache_dir)
 
+    cfg = g.cache_cfg()
     if cmd == 'off' or cmd == 'on':
-        g.set_cfg('CACHE', 'enabled' if cmd == 'on' else 'disabled');
+        g.set_cfg('CACHE', 'enabled' if cmd == 'on' else 'disabled')
         cfg = g.cache_cfg()
         action('Repository cache is now %s.' % str(cfg['cache']).upper())
         action('Cache location \"%s\"' % cfg['cache_dir'])
     elif cmd == 'ls':
-        print 'list'
+        def get_size_(path):
+            size = 0
+            for dirpath, dirs, files in os.walk(path):
+                for f in files:
+                    size += os.path.getsize(os.path.join(dirpath, f))
+            return size
+
+        action('Listing cached repositories in \"%s\"' % cfg['cache_base'])
+        repos = []
+        total_size = 0
+        for dirpath, dirs, files in os.walk(cfg['cache_dir']):
+            dirs[:] = [d for d in dirs  if not d.startswith('.')]
+            if Repo.isrepo(dirpath):
+                repo = Repo().fromrepo(dirpath)
+                url = repo.url
+                size = get_size_(repo.path)
+                total_size += size
+                log('* %s %s\n' % ('{:60}'.format(url), sizeof_fmt(size).rjust(8)))
+                for d in dirs:
+                    dirs.remove(d)
+        log('%s %s\n' % ('{:62}'.format('Total:'), sizeof_fmt(total_size).rjust(8)))
+
     elif cmd == 'purge':
-        cfg = g.cache_cfg()
         action('Purging cached repositories in \"%s\"' % cfg['cache_base'])
-        if os.path.isdir(path):
+        if os.path.isdir(cfg['cache_dir']):
             rmtree_readonly(cfg['cache_dir'])
-        action('Complete')
+
+        action('Purge complete')
     else:
-        cfg = g.cache_cfg()
         action('Repository cache is %s.' % str(cfg['cache']).upper())
         action('Cache location \"%s\"' % cfg['cache_base'])
 


### PR DESCRIPTION
This feature aims to minimize traffic and reduce import times, by making Mbed CLI cache repositories as a default behavior. Caching is done via storing repository indexes under the Mbed CLI user config folder - typically `~/.mbed/mbed-cache/` on UNIX systems, or `%userprofile%/.mbed/mbed-cache/` on Windows systems. 

Compared to a fully checked out repository, indexes are significantly smaller in size and number of files, and contain the whole revision history of that repository. This allows Mbed CLI to quickly create copies of previously downloaded repository indexes and pull/fetch only the latest changes from the remote repositories, therefore dramatically reducing network traffic and download times, especially for big repositories like `mbed-os`.

**Workflow**
No impact to existing workflows.

This PR introduces caching as **default behavior** and also a new `mbed cache` sub-command for cache management:

```
mbed cache [on|off|dir <path>|ls|purge|-h|--help]
```

 * `on` - Turn repository caching on. Will use either the default or the user specified cache directory.
 * `off` - Turn repository caching off. Note that this doesn't purge cached repositories. See "purge".
 * `dir` - Set cache directory. Set to "default" to let mbed CLI determine the cache directory location. Typically this is `~/.mbed/mbed-cache/` on UNIX systems, or `%%userprofile%%/.mbed/mbed-cache/` on Windows systems.
 * `ls` - List cached repositories and their size.
 * `purge` - Purge cached repositories. Note that this doesn't turn caching off.
 * `-h` or `--help` - Print cache command options.

If no sub-command is specified to `mbed cache`, then mbed CLI would print the current cache setting (ENABLED or DISABLED) and the path to the local cache directory.

For safety reasons, Mbed CLI will always use `mbed-cache` subfolder to a user specified location. This ensure that no user files will deleted during `purge` even if the user has specified root/system folder as a cache location (e.g. `mbed cache dir /` or `mbed cache dir C:\`).

**Security notice**: It's generally recommended to user cache location inside your own home directory. If you use cache location outside your user home/profile, then other system users might be able to access the repository cache and therefore the data of the cached repositories


**How this works**

Behind the scenes during `mbed import` or `mbed add`, Mbed CLI will check whether repository caching is enabled and whether a cache folder exists for that repository in the correct location. Location is determined based on URL, e.g.
`https://github.com/ARMmbed/mbed-os-example-client` will be cached in `~/.mbed/mbed-cache/github.com/ARMmbed/mbed-os-example-client' (the actual files of the repositories will not be checked out, just the index).

If repo index exists, Mbed CLI would make a carbon copy to the destination folder and try `fetch` for Git, or `pull` for Mercurial.
 * If `fetch` / `pull` succeeds, then Mbed CLI checks-outs the repository normally.
 * If `fetch`/`pull` fails, then it's highly likely that the remote repository has been rewritten (bad bad repo admin!). In that case Mbed CLI ignores the cached repo, wipes the copy and does a normal clone of the repository, and lastly "feeds" the new/fresh index to the cache.

Listing of cached repositories is done via `mbed cache ls`, e.g.

```
$ mbed cache ls

[mbed] Listing cached repositories in "/Users/mihsto01/.mbed"
* https://github.com/ARMmbed/atmel-rf-driver                            240.4KB
* https://github.com/ARMmbed/easy-connect                               112.3KB
* https://github.com/ARMmbed/esp8266-driver                             161.6KB
* https://github.com/ARMmbed/mbed-client                                  4.3MB
* https://github.com/ARMmbed/mbed-client-c                                5.0MB
* https://github.com/ARMmbed/mbed-client-classic                        436.7KB
* https://github.com/ARMmbed/mbed-client-mbed-tls                       296.8KB
* https://github.com/ARMmbed/mbed-os                                    196.6MB
* https://github.com/ARMmbed/mbed-os-example-client                       8.1MB
* https://github.com/ARMmbed/mcr20a-rf-driver                            93.3KB
* https://github.com/ARMmbed/pal                                          5.6MB
* https://github.com/ARMmbed/stm-spirit1-rf-driver                      384.8KB
* https://github.com/ARMmbed/wifi-x-nucleo-idw01m1                      285.1KB
* https://github.com/ARMmbed/wizfi310-driver                            119.9KB
-------------------------------------------------------------------------------
Total size:                                                             221.8MB
```

**Documentation**
Documentation is included with this PR. There's a new section called "Repository caching".

@AnotherButler please review

**Tests**
Not yet

CC @sg- @theotherjimmy @janjongboom 
Note that due to the additionally stored files, there might be impact to CI systems @JanneKiiskila @studavekar @0xc0170 @adbridge.
