### PR TITLE
Add ability to specify/save profile with configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ target/
 # Doxygen
 html/
 latex/
+
+# PyCharm
+.idea

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1484,7 +1484,7 @@ class Program(object):
     def post_action(self):
         mbed_tools_path = self.get_tools_dir()
 
-        if not mbed_tools_path and (self.is_classic or os.path.exists(os.path.join(self.path, Cfg.file))):
+        if not mbed_tools_path and self.is_classic:
             self.add_tools(os.path.join(self.path, '.temp'))
             mbed_tools_path = self.get_tools_dir()
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1560,11 +1560,18 @@ class Program(object):
             error("Please specify toolchain using the -t switch or set default toolchain using command 'mbed toolchain'", 1)
         return tchain
 
-    def set_defaults(self, target=None, toolchain=None):
+    def get_profile(self, profile=None):
+        profile_cfg = self.get_cfg('PROFILE')
+        profile_cfg = profile_cfg.split() if profile_cfg else []
+        return profile if profile else profile_cfg
+
+    def set_defaults(self, target=None, toolchain=None, profile=None):
         if target and not self.get_cfg('TARGET'):
             self.set_cfg('TARGET', target)
         if toolchain and not self.get_cfg('TOOLCHAIN'):
             self.set_cfg('TOOLCHAIN', toolchain)
+        if profile and not self.get_cfg('PROFILE'):
+            self.set_cfg('PROFILE', (' ').join(profile))
 
     def get_macros(self):
         macros = []
@@ -2399,6 +2406,7 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
 
     target = program.get_target(target)
     tchain = program.get_toolchain(toolchain)
+    profile = program.get_profile(profile)
     macros = program.get_macros()
 
     if compile_config:
@@ -2470,7 +2478,7 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
                 if not reset_dev(detected['port']):
                     error("Unable to reset the target board connected to your system.\nThis might be caused by an old interface firmware.\nPlease check the board page for new firmware.", 1)
 
-    program.set_defaults(target=target, toolchain=tchain)
+    program.set_defaults(target=target, toolchain=tchain, profile=profile)
 
 
 # Test command
@@ -2502,6 +2510,7 @@ def test_(toolchain=None, target=None, compile_list=False, run_list=False, compi
 
     target = program.get_target(target)
     tchain = program.get_toolchain(toolchain)
+    profile = program.get_profile(profile)
     macros = program.get_macros()
     tools_dir = program.get_tools()
     build_and_run_tests = not compile_list and not run_list and not compile_only and not run_only
@@ -2572,7 +2581,7 @@ def test_(toolchain=None, target=None, compile_list=False, run_list=False, compi
                   + args,
                   env=env)
 
-    program.set_defaults(target=target, toolchain=tchain)
+    program.set_defaults(target=target, toolchain=tchain, profile=profile)
 
 
 # Export command

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1192,7 +1192,7 @@ class Repo(object):
 
         for _, scm in sorted_scms:
             main = True
-            cache = self.get_cache(url)
+            cache = self.get_cache(url, scm.name)
 
             # Try to clone with cache ref first
             if cache and not os.path.isdir(path):
@@ -1275,9 +1275,9 @@ class Repo(object):
                 action("Remove untracked library reference \"%s\"" % f)
                 os.remove(f)
 
-    def get_cache(self, url):
+    def get_cache(self, url, scm):
         up = urlparse(formaturl(url, 'https'))
-        if self.cache and up and up.netloc and os.path.isdir(os.path.join(self.cache, up.netloc, re.sub(r'^/', '', up.path))):
+        if self.cache and up and up.netloc and os.path.isdir(os.path.join(self.cache, up.netloc, re.sub(r'^/', '', up.path), '.'+scm)):
             return os.path.join(self.cache, up.netloc, re.sub(r'^/', '', up.path))
 
     def set_cache(self, url):

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2789,6 +2789,15 @@ def toolchain_(name=None, global_cfg=False, supported=False):
         return compile_(supported=supported)
     return config_('toolchain', name, global_cfg=global_cfg)
 
+@subcommand('profile',
+    dict(name='path', nargs='+', help='Default profile path. Example: mbed-os/tools/profiles/develop.json, ./profile-cxx11.json'),
+    dict(name=['-G', '--global'], dest='global_cfg', action='store_true', help='Use global settings, not local'),
+    help='Set or get default profile(s)\n\n',
+    description=(
+        "Set or get default profile\n"
+        "This is an alias to 'mbed config [--global] profile [path ...]'\n"))
+def profile_(path=None, global_cfg=False):
+    return config_('profile', (' ').join(path), global_cfg=global_cfg)
 
 @subcommand('profile',
     dict(name='path', nargs='+', help='Default profile path. Example: mbed-os/tools/profiles/develop.json, ./profile-cxx11.json'),

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2699,7 +2699,7 @@ def detect():
         "Gets, sets or unsets mbed tool configuration options.\n"
         "Options can be global (via the --global switch) or local (per program)\n"
         "Global options are always overridden by local/program options.\n"
-        "Currently supported options: target, toolchain, protocol, depth, cache"))
+        "Currently supported options: target, toolchain, profile, protocol, depth, cache"))
 def config_(var=None, value=None, global_cfg=False, unset=False, list_config=False):
     name = var
     var = str(var).upper()
@@ -2788,6 +2788,17 @@ def toolchain_(name=None, global_cfg=False, supported=False):
     if supported:
         return compile_(supported=supported)
     return config_('toolchain', name, global_cfg=global_cfg)
+
+
+@subcommand('profile',
+    dict(name='path', nargs='+', help='Default profile path. Example: mbed-os/tools/profiles/develop.json, ./profile-cxx11.json'),
+    dict(name=['-G', '--global'], dest='global_cfg', action='store_true', help='Use global settings, not local'),
+    help='Set or get default profile(s)\n\n',
+    description=(
+        "Set or get default profile\n"
+        "This is an alias to 'mbed config [--global] profile [path ...]'\n"))
+def profile_(path=None, global_cfg=False):
+    return config_('profile', (' ').join(path), global_cfg=global_cfg)
 
 
 @subcommand('cache',

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -37,7 +37,7 @@ import tempfile
 
 
 # Application version
-ver = '1.4.0'
+ver = '1.5.0'
 
 # Default paths to Mercurial and Git
 hg_cmd = 'hg'

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2731,6 +2731,9 @@ def config_(var=None, value=None, global_cfg=False, unset=False, list_config=Fal
         if global_cfg:
             # Global configuration
             g = Global()
+            if var == 'PROFILE':
+                action('profile is a local-only option')
+                return
             if unset:
                 g.set_cfg(var, None)
                 action('Unset global %s' % name)
@@ -2800,7 +2803,7 @@ def profile_(path=None, global_cfg=False):
     return config_('profile', (' ').join(path), global_cfg=global_cfg)
 
 @subcommand('profile',
-    dict(name='path', nargs='+', help='Default profile path. Example: mbed-os/tools/profiles/develop.json, ./profile-cxx11.json'),
+    dict(name='path', nargs='*', help='Default profile path. Example: mbed-os/tools/profiles/develop.json, ./profile-cxx11.json'),
     dict(name=['-G', '--global'], dest='global_cfg', action='store_true', help='Use global settings, not local'),
     help='Set or get default profile(s)\n\n',
     description=(

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ LICENSE = open('LICENSE').read()
 
 setup(
     name="mbed-cli",
-    version="1.4.0",
+    version="1.5.0",
     description="ARM mbed command line tool for repositories version control, publishing and updating code from remotely hosted repositories (GitHub, GitLab and mbed.org), and invoking mbed OS own build system and export functions, among other operations",
     long_description=LONG_DESC,
     url='http://github.com/ARMmbed/mbed-cli',

--- a/test/profile_test.py
+++ b/test/profile_test.py
@@ -14,20 +14,55 @@
 from util import *
 import re
 
-def assertprofile(mbed, profile):
-    expected = '[mbed] {}'.format(profile)
+@pytest.fixture
+def empty(mbed):
+    pquery(['python', mbed, 'config', 'root', '.'])
 
-    # write the profile
-    popen(['python', mbed, 'config', 'profile', profile])
-    # read the profile
-    output = pquery(['python', mbed, 'config', 'profile']).strip()
+def config(mbed, *args):
+    call = ('python', mbed) + args
+    return pquery(call)
 
-    assert output == expected
+def assertunset(mbed, *args):
+    assert config(mbed, *args).startswith(
+        '[mbed] No default {} set'.format(args[-1]))
 
-# Tests `mbed config profile`
-def testprofile(mbed):
-    # need to mark dir as an mbed program
-    popen(['python', mbed, 'config', 'root', '.'])
+def assertconfig(mbed, var, value):
+    if value is None:
+        assertunset(mbed, 'config', var)
+    else:
+        config(mbed, 'config', var, value)
+        assert config(mbed, 'config', var) == \
+            '[mbed] {}\n'.format(value)
 
+def assertprofile(mbed, value):
+    if value is None:
+        assertunset(mbed, 'profile')
+    else:
+        config(mbed, 'profile', value)
+        assert config(mbed, 'profile') == \
+            '[mbed] {}\n'.format(value)
+
+
+def test_profile(mbed, empty):
+    '''test `mbed profile`'''
+    assertprofile(mbed, None)
+    assertprofile(mbed, 'profile.json')
     assertprofile(mbed, 'mbed-os/tools/profiles/develop.json')
     assertprofile(mbed, 'mbed-os/tools/profiles/develop.json cxx11_profile.json')
+
+def test_global_profile(mbed, empty):
+    '''test `mbed profile --global`'''
+    assert config(mbed, 'profile', '--global', '~/.mbed_global_profile') \
+        == '[mbed] profile is a local-only option\n'
+
+def test_config_profile(mbed, empty):
+    '''test `mbed config profile`'''
+    assertconfig(mbed, 'profile', None)
+    assertconfig(mbed, 'profile', 'profile.json')
+    assertconfig(mbed, 'profile', 'mbed-os/tools/profiles/develop.json')
+    assertconfig(mbed, 'profile', 'mbed-os/tools/profiles/develop.json cxx11_profile.json')
+
+def test_config_global_profile(mbed):
+    '''attempting to configure a global profile should result in an error message'''
+    assert config(mbed, 'config', '--global', 'profile', '~/.mbed_global_profile') \
+        == '[mbed] profile is a local-only option\n'

--- a/test/profile_test.py
+++ b/test/profile_test.py
@@ -1,0 +1,33 @@
+
+# Copyright (c) 2016 ARM Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+
+from util import *
+import re
+
+def assertprofile(mbed, profile):
+    expected = '[mbed] {}'.format(profile)
+
+    # write the profile
+    popen(['python', mbed, 'config', 'profile', profile])
+    # read the profile
+    output = pquery(['python', mbed, 'config', 'profile']).strip()
+
+    assert output == expected
+
+# Tests `mbed config profile`
+def testprofile(mbed):
+    # need to mark dir as an mbed program
+    popen(['python', mbed, 'config', 'root', '.'])
+
+    assertprofile(mbed, 'mbed-os/tools/profiles/develop.json')
+    assertprofile(mbed, 'mbed-os/tools/profiles/develop.json cxx11_profile.json')

--- a/test/sync_update_test.py
+++ b/test/sync_update_test.py
@@ -58,7 +58,6 @@ def test_sync_update_remove(mbed, testrepos):
 # Tests if adding a library is carried over sync/update
 def test_sync_update_add(mbed, testrepos):
     test1 = testrepos[0]
-    test3 = testrepos[2]
     popen(['python', mbed, 'import', test1, 'testimport'])
 
     with cd('test1/test2'):
@@ -85,7 +84,6 @@ def test_sync_update_add(mbed, testrepos):
 # Tests if moving a library is carried over sync/update
 def test_sync_update_move(mbed, testrepos):
     test1 = testrepos[0]
-    test3 = testrepos[2]
     popen(['python', mbed, 'import', test1, 'testimport'])
 
     with cd('test1/test2'):

--- a/test/util.py
+++ b/test/util.py
@@ -162,6 +162,7 @@ def testrepos(mbed, request):
 
     with cd('test1/test2/test3'):
         with open('test4.lib', 'w') as f:
+            hash = 'none'
             with cd('test4'):
                 if scm() == 'git':
                     hash = pquery(['git', 'rev-parse', 'HEAD'])

--- a/tools/bash_completion/generator.py
+++ b/tools/bash_completion/generator.py
@@ -25,31 +25,26 @@ def getHelpTxt(command=None):
     return out
 
 def getTargetCode():
-    txt = ''
     with open("templates/target.tmplt") as fp:
         txt = fp.read()
     return txt
 
 def getToolchainCode():
-    txt = ''
     with open("templates/toolchain.tmplt") as fp:
         txt = fp.read()
     return txt
 
 def getSCMCode():
-    txt = ''
     with open("templates/scm.tmplt") as fp:
         txt = fp.read()
     return txt
 
 def getIDECode():
-    txt = ''
     with open("templates/ide.tmplt") as fp:
         txt = fp.read()
     return txt
 
 def getProtocolCode():
-    txt = ''
     with open("templates/protocol.tmplt") as fp:
         txt = fp.read()
     return txt
@@ -159,8 +154,6 @@ def parseCommands():
 
 
 def generateMain(commands):
-    tmplt = ""
-
     txt = []
 
     with open("templates/mbed.tmplt") as fp:
@@ -172,7 +165,6 @@ def generateMain(commands):
 
 
 def generateCompleters(commands):
-    tmplt = ""
     txt = []
 
     renderer = pystache.Renderer(escape=lambda u: u)
@@ -188,7 +180,7 @@ def generateCompleters(commands):
     return txt
 
 
-def generateBoilerPlate(commands):
+def generateBoilerPlate(_):
     txt = []
 
     with open("templates/boilerplate.tmplt") as fp:


### PR DESCRIPTION
This pull request is to try and resolve #633 

This patch treats the profile like the target and the toolchain currently are; it has methods in the Program class for getting and setting from a Cfg, and is automatically saved to the config file as a default if set at the command line. Additionally, `mbed config profile` works as expected.

Multiple profiles are handed by allowing the value to be a list of space-separated strings.

Tests for the `mbed config profile` functionality are in `test/profile_test.py`