### PR TITLE
New feature: Safe repo urls

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1241,7 +1241,7 @@ class Repo(object):
 
     def write(self):
         up = urlparse(self.url)
-        url = up._replace(netloc=up.hostname).geturl() # strip auth string
+        url = up._replace(netloc=up.hostname + (':'+str(up.port) if up.port else '')).geturl() # strip auth string
 
         if os.path.isfile(self.lib):
             with open(self.lib) as f:
@@ -1731,7 +1731,7 @@ def formaturl(url, format="default"):
     else:
         m = re.match(regex_repo_url, url)
         if m and m.group(1) == '': # no protocol specified, probably ssh string like "git@github.com:ARMmbed/mbed-os.git"
-            url = 'ssh://%s%s%s/%s.git' % (m.group(2) or 'git@', m.group(6), m.group(7) or '', m.group(8)) # convert to common ssh URL-like format
+            url = 'ssh://%s%s%s/%s' % (m.group(2) or 'git@', m.group(6), m.group(7) or '', m.group(8)) # convert to common ssh URL-like format
             m = re.match(regex_repo_url, url)
 
         if m:

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -126,7 +126,7 @@ mbed_lib_url = 'https://mbed.org/users/mbed_official/code/mbed/builds/'
 mbed_sdk_tools_url = 'https://mbed.org/users/mbed_official/code/mbed-sdk-tools'
 
 # a list of public SCM service (github/butbucket) which support http, https and ssh schemas
-public_repo_services = ['bitbucket.org', 'github.com', 'gitlab.com']
+public_scm_services = ['bitbucket.org', 'github.com', 'gitlab.com']
 
 
 # verbose logging
@@ -1096,7 +1096,7 @@ class Repo(object):
 
     @classmethod
     def isinsecure(cls, url):
-        up = urlparse(url, 'https')
+        up = urlparse(url)
         return not up or not up.scheme or up.scheme not in ['http', 'https', 'ssh', 'git'] or (up.port and int(up.port) not in [22, 80, 443])
 
     @property
@@ -1178,7 +1178,7 @@ class Repo(object):
                 pass
         return self.scm.remove(dest, *args, **kwargs)
 
-    def clone(self, url, path, rev=None, depth=None, protocol=None, insecure=False, **kwargs):
+    def clone(self, url, path, rev=None, depth=None, protocol=None, **kwargs):
         # Sorted so repositories that match urls are attempted first
         info("Trying to guess source control management tool. Supported SCMs: %s" % ', '.join([s.name for s in scms.values()]))
         for _, scm in scms.items():
@@ -1246,14 +1246,14 @@ class Repo(object):
         if os.path.isfile(self.lib):
             with open(self.lib) as f:
                 lib_repo = Repo.fromurl(f.read().strip())
-                if (formaturl(lib_repo.url, 'https') == formaturl(url, 'https') # match URLs in common format (https)
-                        and (lib_repo.rev == self.rev                              # match revs, even if rev is None (valid for repos with no revisions)
+                if (formaturl(lib_repo.url, 'https') == formaturl(url, 'https') # match URLs in common schema (https)
+                        and (lib_repo.rev == self.rev                           # match revs, even if rev is None (valid for repos with no revisions)
                              or (lib_repo.rev and self.rev
                                  and lib_repo.rev == self.rev[0:len(lib_repo.rev)]))):  # match long and short rev formats
                     #print self.name, 'unmodified'
                     return
 
-        if up.hostname in public_repo_services:
+        if up.hostname in public_scm_services:
             # Safely convert repo URL to https schema if this is a public SCM service (github/butbucket), supporting all schemas.
             # This allows anonymous cloning of public repos without having to have ssh keys and associated accounts at github/bitbucket/etc.
             # Without this anonymous users will get clone errors with ssh repository links even if the repository is public.

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1097,7 +1097,8 @@ class Repo(object):
     @classmethod
     def isinsecure(cls, url):
         up = urlparse(url)
-        return not up or not up.scheme or up.scheme not in ['http', 'https', 'ssh', 'git'] or (up.port and int(up.port) not in [22, 80, 443])
+        return False
+#        return not up or (up.scheme and up.scheme not in ['http', 'https', 'ssh', 'git']) or (up.port and int(up.port) not in [22, 80, 443])
 
     @property
     def lib(self):
@@ -1241,7 +1242,10 @@ class Repo(object):
 
     def write(self):
         up = urlparse(self.url)
-        url = up._replace(netloc=up.hostname + (':'+str(up.port) if up.port else '')).geturl() # strip auth string
+        if up.hostname:
+            url = up._replace(netloc=up.hostname + (':'+str(up.port) if up.port else '')).geturl() # strip auth string
+        else:
+            url = self.url # use local repo "urls" as is
 
         if os.path.isfile(self.lib):
             with open(self.lib) as f:

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1097,7 +1097,7 @@ class Repo(object):
     @classmethod
     def isinsecure(cls, url):
         up = urlparse(url)
-        return not up or (up.scheme and up.scheme not in ['http', 'https', 'ssh', 'git']) or (up.port and int(up.port) not in [22, 80, 443])
+        return (not up) or (up.scheme and up.scheme not in ['http', 'https', 'ssh', 'git']) or (up.port and int(up.port) not in [22, 80, 443])
 
     @property
     def lib(self):

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -30,6 +30,7 @@ import errno
 import ctypes
 from itertools import chain, izip, repeat
 from urlparse import urlparse
+import urllib
 import urllib2
 import zipfile
 import argparse
@@ -1277,8 +1278,8 @@ class Repo(object):
 
     def get_cache(self, url, scm):
         up = urlparse(formaturl(url, 'https'))
-        if self.cache and up and up.netloc and os.path.isdir(os.path.join(self.cache, up.netloc, re.sub(r'^/', '', up.path), '.'+scm)):
-            return os.path.join(self.cache, up.netloc, re.sub(r'^/', '', up.path))
+        if self.cache and up and up.netloc and os.path.isdir(os.path.join(self.cache, urllib.quote(up.netloc), urllib.quote(re.sub(r'^/', '', up.path), '.'+scm))):
+            return os.path.join(self.cache, urllib.quote(up.netloc), urllib.quote(re.sub(r'^/', '', up.path)))
 
     def set_cache(self, url):
         up = urlparse(formaturl(url, 'https'))

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1097,8 +1097,7 @@ class Repo(object):
     @classmethod
     def isinsecure(cls, url):
         up = urlparse(url)
-        return False
-#        return not up or (up.scheme and up.scheme not in ['http', 'https', 'ssh', 'git']) or (up.port and int(up.port) not in [22, 80, 443])
+        return not up or (up.scheme and up.scheme not in ['http', 'https', 'ssh', 'git']) or (up.port and int(up.port) not in [22, 80, 443])
 
     @property
     def lib(self):

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -982,7 +982,7 @@ class Repo(object):
             repo.rev = m_bld_ref.group(8)
             repo.is_build = True
         elif m_repo_ref:
-            repo.name = os.path.basename(path or m_repo_ref.group(2))
+            repo.name = re.sub(r'\.(git|hg)/?$', '', os.path.basename(path or m_repo_ref.group(2)))
             repo.path = os.path.abspath(path or os.path.join(getcwd(), repo.name))
             repo.url = formaturl(m_repo_ref.group(1))
             repo.rev = m_repo_ref.group(3)

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1922,7 +1922,7 @@ def import_(url, path=None, ignore=False, depth=None, protocol=None, insecure=Fa
     insecure = insecure or Program().get_cfg('INSECURE')
 
     if not insecure and Repo.isinsecure(url):
-        error("Cannot import \"%s\" in \"%s\" due to arbitrary service schema/port in the repository URL.\nRepositories are usually hosted on service port 443 (https), 80 (http) and 22 (ssh)\nYou can use \"--insecure\" switch enable the use arbitrary repository URLs." % (repo.url, repo.path), 255)
+        error("Cannot import \"%s\" in \"%s\" due to arbitrary service schema/port in the repository URL.\nRepositories are usually hosted on service port 443 (https), 80 (http), or 22 (ssh).\nYou can use the \"--insecure\" switch to enable the use of arbitrary repository URLs." % (repo.url, repo.path), 255)
 
     if os.path.isdir(repo.path) and len(os.listdir(repo.path)) > 1:
         error("Directory \"%s\" is not empty. Please ensure that the destination folder is empty." % repo.path, 1)

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1182,7 +1182,7 @@ class Repo(object):
     def clone(self, url, path, rev=None, depth=None, protocol=None, **kwargs):
         # Sorted so repositories that match urls are attempted first
         info("Trying to guess source control management tool. Supported SCMs: %s" % ', '.join([s.name for s in scms.values()]))
-        for _, scm in scms.items():
+        for scm in scms.values():
             main = True
             cache = self.get_cache(url, scm.name)
 
@@ -1261,7 +1261,7 @@ class Repo(object):
             # Safely convert repo URL to https schema if this is a public SCM service (github/butbucket), supporting all schemas.
             # This allows anonymous cloning of public repos without having to have ssh keys and associated accounts at github/bitbucket/etc.
             # Without this anonymous users will get clone errors with ssh repository links even if the repository is public.
-            # See hhttps://help.github.com/articles/which-remote-url-should-i-use/
+            # See https://help.github.com/articles/which-remote-url-should-i-use/
             url = formaturl(url, 'https')
 
         ref = url.rstrip('/') + '/' + (('' if self.is_build else '#') + self.rev if self.rev else '')

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1276,19 +1276,22 @@ class Repo(object):
                 action("Remove untracked library reference \"%s\"" % f)
                 os.remove(f)
 
-    def get_cache(self, url, scm):
+    def url2cachedir(self, url):
         up = urlparse(formaturl(url, 'https'))
-        if self.cache and up and up.netloc and os.path.isdir(os.path.join(self.cache, urllib.quote(up.netloc), urllib.quote(re.sub(r'^/', '', up.path), '.'+scm))):
+        if self.cache and up and up.netloc:
             return os.path.join(self.cache, urllib.quote(up.netloc), urllib.quote(re.sub(r'^/', '', up.path)))
 
+    def get_cache(self, url, scm):
+        cpath = self.url2cachedir(url)
+        if cpath and os.path.isdir(os.path.join(cpath, '.'+scm)):
+            return cpath
+
     def set_cache(self, url):
-        up = urlparse(formaturl(url, 'https'))
-        if self.cache and up and up.netloc and os.path.isdir(self.path):
-            cpath = os.path.join(self.cache, up.netloc, re.sub(r'^/', '', up.path))
+        cpath = self.url2cachedir(url)
+        if cpath and os.path.isdir(self.path):
             try:
                 if not os.path.isdir(cpath):
                     os.makedirs(cpath)
-
                 scm_dir = '.'+self.scm.name
                 if os.path.isdir(os.path.join(cpath, scm_dir)):
                     rmtree_readonly(os.path.join(cpath, scm_dir))


### PR DESCRIPTION
This series of commits adds a sense of "secure" and "insecure" URLs to Mbed CLI.

# Security and Liability in Mbed CLI

A user of Mbed CLI does not know about every single repository URL that will be accessed/cloned during `mbed import` and `mbed add`. Unlike the `git clone <url>` command, where end-user is de-facto aware what's being cloned (essentially it's a "consensual clone" as they can see the URL before executing `git`), Mbed CLI clones many repositories recursively without prior consent or user awareness, except for the starting repository or program URL.

This poses some challenges, including legally, as an end-user could blame Mbed CLI for causing their `git` or `hg` to try to access a funky URL/service port.

For example, combining the recursive nature of Mbed CLI with bad intentions, could lead to terrifying results. It's not hard to imagine a malicious program containing 100s .lib files pointing at different ports at `b1-rtr0-hsrp.jpl.nasa.gov` (as repo URLs), which, once mbed CLI start cracking on it, would look a lot like port scanning. Making many connection attempts on a government monitored network, like NASA's, can get you in real trouble.

Furthermore, in many corporate networks, any connection attempt on arbitrary ports (usually below port 1024), is being flagged, logged and reported - even if it was for all the good reasons.

With everything said above `--insecure` provides this user consent, effectively acting as a legally binding agreement that the end-user know what they're doing.

## Secure URLs

These URLs specify the scheme and either do not specify the port of the remote service, or specify the service to have port 22, 80 or 443.

## Insecure URLs

Mbed CLI identifies insecure URLs as URLs that are missing scheme information, or specifie a port other than 22, 80 or 443. When an insecure URL is present on the command line, in a `.lib` file or in a `.bld` file, Mbed CLI refuses to use the URL and exits with an error. A user may explicitly ask Mbed CLI to use these URLs by specifying the `--insecure` option on the command line.