### PR TITLE
New feature: Offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,11 @@ For safety reasons, Mbed CLI uses the `mbed-cache` subfolder to a user specified
 
 **Security notice**: If you use cache location outside your user home/profile directory, then other system users might be able to access the repository cache and therefore the data of the cached repositories.
 
+### Offline mode
+Through the caching feature in Mbed CLI, you can enable offline mode, which will use the already cached repositories on your system. You can enable offline mode by adding `--offline` switch to `mbed import`, `mbed add`, `mbed update` and `mbed new`.
+
+In offline mode, Mbed CLI will look up for locally cached repositories and use them without fetching new content from their remote repositories. This is particularly useful if for example you are in a plane and you'd like to create another Mbed OS project (assuming you've imported or crated one before), but you don't have access to Internet. By using the command `mbed new <project_name> --offline`, you will be able to create the project with Mbed OS included.
+
 ## Mbed CLI configuration
 
 You can streamline many options in Mbed CLI with global and local configuration.

--- a/README.md
+++ b/README.md
@@ -875,9 +875,10 @@ For safety reasons, Mbed CLI uses the `mbed-cache` subfolder to a user specified
 **Security notice**: If you use cache location outside your user home/profile directory, then other system users might be able to access the repository cache and therefore the data of the cached repositories.
 
 ### Offline mode
-Through the caching feature in Mbed CLI, you can enable offline mode, which will use the already cached repositories on your system. You can enable offline mode by adding `--offline` switch to `mbed import`, `mbed add`, `mbed update` and `mbed new`.
 
-In offline mode, Mbed CLI will look up for locally cached repositories and use them without fetching new content from their remote repositories. This is particularly useful if for example you are in a plane and you'd like to create another Mbed OS project (assuming you've imported or crated one before), but you don't have access to Internet. By using the command `mbed new <project_name> --offline`, you will be able to create the project with Mbed OS included.
+Through the caching feature in Mbed CLI, you can enable offline mode, which uses the already cached repositories on your system. You can enable offline mode by adding the `--offline` switch to `mbed import`, `mbed add`, `mbed update` and `mbed new`.
+
+In offline mode, Mbed CLI looks up locally cached repositories and uses them without fetching new content from their remote repositories. This is particularly useful if for example you are in a plane and you'd like to create another Mbed OS project (assuming you've imported or created one before), but you don't have access to the internet. By using the command `mbed new <project_name> --offline`, you can create the project with Mbed OS included.
 
 ## Mbed CLI configuration
 

--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,7 @@ test:
         - cd .tests/bld-test/mbed && mbed update 85 --clean
         - cd .tests/bld-test && mbed update --clean
         - cd .tests/bld-test && mbed compile -m LPC1768 -j 0
+        - cd .tests && mbed new new-offline --offline
         - cd .tests && mbed new supported-tests
         - |-
             cd .tests/supported-tests

--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,7 @@ test:
         - cd .tests && mbed import https://github.com/ARMmbed/mbed-os-example-mesh-minimal offline-test
         - cd .tests/offline-test && mbed update mbed-os-5.5.6 --offline
         - cd .tests/offline-test && mbed update mbed-os-5.7.5 --offline
+        - cd .tests && mbed import https://github.com/ARMmbed/mbed-os-example-mesh-minimal offline-test2 --offline
         - cd .tests && mbed new supported-tests
         - |-
             cd .tests/supported-tests

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ test:
         - mbed toolchain -G GCC_ARM
         - mbed target -G K64F
         - mbed config -G protocol ssh
+        - mbed config -G --list
         - cd .tests && mbed new new-test
         - cd .tests/new-test && mbed ls
         - cd .tests/new-test && mbed releases -r

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,9 @@ test:
         - cd .tests/bld-test/mbed && mbed update 85 --clean
         - cd .tests/bld-test && mbed update --clean
         - cd .tests/bld-test && mbed compile -m LPC1768 -j 0
-        - cd .tests && mbed new new-offline --offline
+        - cd .tests && mbed import https://github.com/ARMmbed/mbed-os-example-mesh-minimal offline-test
+        - cd .tests/offline-test && mbed update mbed-os-5.5.6 --offline
+        - cd .tests/offline-test && mbed update mbed-os-5.7.5 --offline
         - cd .tests && mbed new supported-tests
         - |-
             cd .tests/supported-tests

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1221,7 +1221,7 @@ class Repo(object):
             # Main clone routine if the clone with cache ref failed (might occur if cache ref is dirty)
             if main:
                 if offline:
-                    error("Unable to clone repository \"%s\" in offline mode ('--offline' used)." % url)
+                    continue
                 try:
                     scm.clone(url, path, depth=depth, protocol=protocol, **kwargs)
                 except ProcessException:
@@ -1235,6 +1235,11 @@ class Repo(object):
             self.ignores()
             self.set_cache(url)
             return True
+
+        if offline:
+            error("Unable to clone repository \"%s\" in offline mode ('--offline' used)." % url)
+            if os.path.isdir(path):
+                rmtree_readonly(path)
 
         return False
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2174,7 +2174,7 @@ def update(rev=None, clean=False, clean_files=False, clean_deps=False, ignore=Fa
         except ProcessException as e:
             err = "Unable to update \"%s\" to %s" % (repo.name, repo.revtype(rev))
             if offline:
-                err = err + "\nThis might be caused by offline mode ('--offline' used).\nYou should try without offline mode."
+                err = err + "\nThis might be caused by offline mode ('--offline' used). You should try without offline mode."
             elif depth:
                 err = err + ("\nThis might be caused by the '--depth' option, which prevents fetching the whole revision history." % (repo.revtype(repo.rev)))
             if ignore:


### PR DESCRIPTION
Now that the `mbed cache` is a default Mbed CLI feature (since v1.5.0), a new offline mode feature can take benefit from it. Offline mode is achieved by utilize the cache for various Mbed CLI operations and also preventing Mbed CLI to access remote repositories to avoid connection errors while in offline.

**Workflow**
No impact to existing workflows.

This feature adds `--offline` switch to `mbed import`, `mbed add`, `mbed update` and `mbed new` to enable offline mode as described above.

**How this works**
While using `--offline` for `mbed import/add/update/new`, Mbed CLI will look up for locally cached repositories and use them without fetching new content from remote repositories. 
* If a repository is not cached, an error will be printed that the repository cannot be imported due to offline mode being enabled (even if connection is present).
* If a repository is cached, there might be a corner case where one cached repository references another cached repository, but the local cache for the later is older and therefore the referenced hash is missing.

Lastly, Mbed CLI will print a banner when `--offline` is used to inform the user that they are in offline mode.

```
$ mbed import https://github.com/ARMmbed/mbed-os-example-mesh-minimal --offline

.=============================== OFFLINE MODE ================================.
|   Offline mode is enabled. No connections to remote repositories will be    |
|           made and only locally cached repositories will be used.           |
|   This might break some actions if non-cached repositories are referenced.  |
'============================================================================='

[mbed] Importing program "mesh-minimal" from "https://github.com/ARMmbed/mbed-os-example-mesh-minimal" at latest revision in the current branch
[mbed] Adding library "atmel-rf-driver" from "https://github.com/ARMmbed/atmel-rf-driver" at rev #2cd9abba3e37
[mbed] Adding library "mbed-os" from "https://github.com/ARMmbed/mbed-os" at rev #ad284b28064b
[mbed] Adding library "mcr20a-rf-driver" from "https://github.com/ARMmbed/mcr20a-rf-driver" at rev #9aac10474702
[mbed] Adding library "sd-driver" from "https://github.com/ARMmbed/sd-driver" at rev #51dc1d2b2c07
```

**Documentation**
Documentation is not included with this PR. @AnotherButler please advise where offline mode should be mentioned. Perhaps in https://github.com/ARMmbed/mbed-cli#repository-caching or https://github.com/ARMmbed/mbed-cli#importing-an-existing-program, or both?

**Tests**
`mbed new --offline` and `mbed update --offline` is tested via circle.yml

Resolves #351 