### PR TITLE
README - don't update to PIP version 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Important note - do not use Pip version 10.0!
+
+Pip version 10 is incompatible with current versions of `mbed cli`.
+
 ## Introduction
 
 Arm Mbed CLI is the name of the Arm Mbed command-line tool, packaged as `mbed-cli`. Mbed CLI enables Git- and Mercurial-based version control, dependencies management, code publishing, support for remotely hosted repositories (GitHub, GitLab and mbed.org), use of the Arm Mbed OS build system and export functions and other operations.


### PR DESCRIPTION
We should really mention that don't update to `pip` version 10.0.