### PR TITLE
Fix: Add python_requires to specify compatible python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,5 @@ setup(
             'mbed-cli=mbed.mbed:main',
         ]
     },
+    python_requires='>=2.7.10, <3',
 )


### PR DESCRIPTION
 This PR adds python_requires to specify which versions of python Mbed CLI is compatible with.

Addresses #659 