### PR TITLE
New feature: Serial Terminal (revised)

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,13 +527,12 @@ There are various options to `mbed sterm`:
 You can also set default port, baudrate and echo mode using the `TERM_PORT`, `TERM_BAUDRATE` and `TERM_ECHO` Mbed CLI configuration options.
 
 The following shortcuts are available within the serial terminal:
-- Quit: `CTRL+C` or `CTRL+J`
-- Reset: `CTRL+B` or `CTRL+R`
-- Echo toggle: `CTRL+E`
-- Terminal information: `TAB` or `CTRL+I`
-- Help: `CTRL+H`
-- Menu: `CTRL+T`
-- Change baud rate: `CTRL+T+B`
+- CTRL+B - Send Break (reset target)
+- CTRL+C - Exit terminal
+- CTRL+E - Toggle local echo
+- CTRL+H - Help
+- CTRL+T - Menu escape key
+- _Even more shortcuts are available through the Menu shortcut. Check the help within the serial terminal (CTRL+H).__
 
 To automate things, you can also add the `--sterm` option to `mbed compile -f` to compile a new program, flash the program/firmware image to the connected target and then open serial terminal to it's COM port:
 

--- a/README.md
+++ b/README.md
@@ -514,6 +514,33 @@ $ mbed export -i uvision -m K64F
 
 Mbed CLI creates a `.uvprojx` file in the projectfiles/uvision folder. You can open the project file with uVision.
 
+### Serial terminal
+
+You can open a serial terminal to the COM port of a connected Mbed target (usually board) using the `mbed sterm` command. If no COM port is specified, Mbed CLI will attempt to detect the connected Mbed targets and their COM ports.
+
+There are various options to `mbed sterm`:
+* `--port <COM port>` to specify system COM port to connect to.
+* `--baudrate <numeric>` to select the communication baudrate, where the default value is 9600.
+* `--echo <on|off>` to switch local echo (default is `on`).
+* `--reset` to reset the connected target by sending Break before opening the serial terminal.
+
+You can also set default port, baudrate and echo mode using the `TERM_PORT`, `TERM_BAUDRATE` and `TERM_ECHO` Mbed CLI configuration options.
+
+The following shortcuts are available within the serial terminal:
+- Quit: `CTRL+C` or `CTRL+J`
+- Reset: `CTRL+B` or `CTRL+R`
+- Echo toggle: `CTRL+E`
+- Terminal information: `TAB` or `CTRL+I`
+- Help: `CTRL+H`
+- Menu: `CTRL+T`
+- Change baud rate: `CTRL+T+B`
+
+To automate things, you can also add the `--sterm` option to `mbed compile -f` to compile a new program, flash the program/firmware image to the connected target and then open serial terminal to it's COM port:
+
+```
+$ mbed compile -t GCC_ARM -m K64F -f --sterm
+```
+
 ## Testing
 
 Use the `mbed test` command to compile and run tests.

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2749,7 +2749,7 @@ def detect(reset=False, sterm=False):
     with cd(program.path):
         tools_dir = program.get_tools_dir()
 
-    if tools_dir:
+    if tools_dir and not (reset or sterm):
         # Prepare environment variables
         env = program.get_env()
 
@@ -2762,7 +2762,9 @@ def detect(reset=False, sterm=False):
             if very_verbose:
                 error(str(e))
     else:
-        warning("The mbed OS tools were not found in \"%s\". \nLimited information will be shown about connected mbed targets/boards" % program.path)
+        if not tools_dir:
+            warning("The mbed OS tools were not found in \"%s\". \nLimited information will be shown about connected mbed targets/boards" % program.path)
+
         targets = program.get_detected_targets()
         if targets:
             unknown_found = False

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2390,7 +2390,7 @@ def status_(ignore=False):
     dict(name='--build', help='Build directory. Default: build/'),
     dict(name=['-c', '--clean'], action='store_true', help='Clean the build directory before compiling'),
     dict(name=['-f', '--flash'], action='store_true', help='Flash the built firmware onto a connected target.'),
-    dict(name=['-s', '--sterm'], action='store_true', help='Open serial terminal after compiling. Can be chained with --flash'),
+    dict(name=['--sterm'], action='store_true', help='Open serial terminal after compiling. Can be chained with --flash'),
     dict(name=['-N', '--artifact-name'], help='Name of the built program or library'),
     dict(name=['-S', '--supported'], dest='supported', const=True, choices=["matrix", "toolchains", "targets"], nargs="?", help='Shows supported matrix of targets and toolchains'),
     dict(name='--app-config', dest="app_config", help="Path of an app configuration file (Default is to look for 'mbed_app.json')"),

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -34,6 +34,7 @@ import urllib2
 import zipfile
 import argparse
 import tempfile
+from mbed_cdc import mbed_cdc
 
 
 # Application version
@@ -1752,103 +1753,6 @@ def formaturl(url, format="default"):
     return url
 
 
-def cdc(port, reset=False, sterm=False, baudrate=9600, timeout=10):
-    from serial import Serial, SerialException
-
-    def get_instance(*args, **kwargs):
-        try:
-            serial_port = Serial(*args, **kwargs)
-            serial_port.flush()
-        except Exception as e:
-            error("Unable to open serial port connection to \"%s\"" % port)
-            return False
-        return serial_port
-
-    def cdc_reset(serial_instance):
-        try:
-            serial_instance.sendBreak()
-        except:
-            try:
-                serial_instance.setBreak(False) # For Linux the following setBreak() is needed to release the reset signal on the target mcu.
-            except:
-                result = False
-
-    def cdc_term(serial_instance):
-        import serial.tools.miniterm as miniterm
-
-        term = miniterm.Miniterm(serial_instance, echo=True)
-        term.exit_character = '\x03'
-        term.menu_character = '\x14'
-        term.set_rx_encoding('UTF-8')
-        term.set_tx_encoding('UTF-8')
-        def cli_writer():
-            menu_active = False
-            while term.alive:
-                try:
-                    c = term.console.getkey()
-                except KeyboardInterrupt:
-                    c = '\x03'
-                if not term.alive:
-                    break
-                if menu_active:
-                    term.handle_menu_key(c)
-                    menu_active = False
-                elif c == term.menu_character:
-                    menu_active = True # next char will be for menu
-                elif c == '\x02' or  c == '\x12': # ctrl+b/ctrl+r sendbreak
-                    cdc_reset(term.serial)
-                elif c == '\x03' or c == '\x1d': # ctrl+c/ctrl+]
-                    term.stop()
-                    term.alive = False
-                    break
-                elif c == '\x05': # ctrl+e
-                    term.echo = not term.echo
-                elif c == '\x08': # ctrl+e
-                    print term.get_help_text()
-                elif c == '\t': # tab/ctrl+i
-                    term.dump_port_settings()
-                else:
-                    text = c
-                    for transformation in term.tx_transformations:
-                        text = transformation.tx(text)
-                    term.serial.write(term.tx_encoder.encode(text))
-                    if term.echo:
-                        echo_text = c
-                        for transformation in term.tx_transformations:
-                            echo_text = transformation.echo(echo_text)
-                        term.console.write(echo_text)
-        term.writer = cli_writer
-        action('--- Terminal on {p.name} - {p.baudrate},{p.bytesize},{p.parity},{p.stopbits} ---\n'.format(p=term.serial))
-        action('--- Quit: CTRL+C | Reset: CTRL+B | Echo: CTRL+E ---')
-        action('--- Info: TAB    | Help:  Ctrl+H | Menu: Ctrl+T ---')
-        term.start()
-        try:
-            term.join(True)
-        except KeyboardInterrupt:
-            pass
-        term.join()
-        term.close()
-
-    result = False
-    serial_port = get_instance(port, baudrate=baudrate, timeout=timeout)
-    if serial_port:
-        serial_port.reset_input_buffer()
-        if reset:
-            cdc_reset(serial_port)
-            result = True
-
-        if sterm:
-            if not serial_port.is_open:
-                serial_port = get_instance(port, baudrate=baudrate, timeout=timeout)
-            try:
-                cdc_term(serial_port)
-                result = True
-            except:
-                pass
-
-    return result
-
-
 # Subparser handling
 parser = argparse.ArgumentParser(prog='mbed',
     description="Command-line code management tool for ARM mbed OS - http://www.mbed.com\nversion %s\n\nUse 'mbed <command> -h|--help' for detailed help.\nOnline manual and guide available at https://github.com/ARMmbed/mbed-cli" % ver,
@@ -2566,7 +2470,7 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
                     error("Unable to flash the target board connected to your system.", 1)
 
             if flash or sterm:
-                if not cdc(detected['port'], reset=flash, sterm=sterm):
+                if not mbed_cdc(detected['port'], reset=flash, sterm=sterm):
                     error("Unable to reset the target board connected to your system.\nThis might be caused by an old interface firmware.\nPlease check the board page for new firmware.", 1)
 
     program.set_defaults(target=target, toolchain=tchain)
@@ -2774,7 +2678,7 @@ def detect(reset=False, sterm=False):
                     action("Detected unknown target connected to \"%s\" and using com port \"%s\"" % (target['mount'], target['serial']))
                 else:
                     action("Detected \"%s\" connected to \"%s\" and using com port \"%s\"" % (target['name'], target['mount'], target['serial']))
-                cdc(target['serial'], reset=reset, sterm=sterm)
+                mbed_cdc(target['serial'], reset=reset, sterm=sterm)
 
             if unknown_found:
                 warning("If you're developing a new target, you can mock the device to continue your development. "

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2554,7 +2554,7 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
                 try:
                     from mbed_host_tests.host_tests_toolbox import flash_dev
                 except (IOError, ImportError, OSError):
-                    error("The '-f/--flash' option requires that the 'mbed-greentea' python module is installed.\nYou can install mbed-ls by running 'pip install mbed-greentea'.", 1)
+                    error("The '-f/--flash' option requires that the 'mbed-greentea' python module is installed.\nYou can install mbed-greentea by running 'pip install mbed-greentea'.", 1)
 
             if flash:
                 fw_name = artifact_name if artifact_name else program.name
@@ -2780,7 +2780,7 @@ def detect(reset=False, sterm=False):
                 warning("If you're developing a new target, you can mock the device to continue your development. "
                         "Use 'mbedls --mock ID:NAME' to do so (see 'mbedls --help' for more information)")
         else:
-            error("This command requires that the 'mbed-greentea' python module is installed.\nYou can install mbed-ls by running 'pip install mbed-greentea'.", 1)
+            error("This command requires that the 'mbed-greentea' python module is installed.\nYou can install mbed-greentea by running 'pip install mbed-greentea'.", 1)
 
 
 # Generic config command

--- a/mbed/mbed_cdc.py
+++ b/mbed/mbed_cdc.py
@@ -1,0 +1,107 @@
+from serial import Serial, SerialException
+import serial.tools.miniterm as miniterm
+
+def mbed_cdc(port, reset=False, sterm=False, baudrate=9600, timeout=10, print_term_header=True):
+    def get_instance(*args, **kwargs):
+        try:
+            serial_port = Serial(*args, **kwargs)
+            serial_port.flush()
+        except Exception as e:
+            error("Unable to open serial port connection to \"%s\"" % port)
+            return False
+        return serial_port
+
+    def cdc_reset(serial_instance):
+        try:
+            serial_instance.sendBreak()
+        except:
+            try:
+                serial_instance.setBreak(False) # For Linux the following setBreak() is needed to release the reset signal on the target mcu.
+            except:
+                result = False
+
+    def cdc_term(serial_instance):
+        term = miniterm.Miniterm(serial_instance, echo=True)
+        term.exit_character = '\x03'
+        term.menu_character = '\x14'
+        term.set_rx_encoding('UTF-8')
+        term.set_tx_encoding('UTF-8')
+
+        def console_print(text):
+            term.console.write('--- %s ---\n' % text)
+
+        def input_handler():
+            menu_active = False
+            while term.alive:
+                try:
+                    c = term.console.getkey()
+                except KeyboardInterrupt:
+                    c = '\x03'
+                if not term.alive:
+                    break
+                if menu_active:
+                    term.handle_menu_key(c)
+                    menu_active = False
+                elif c == term.menu_character:
+                    console_print('[MENU]')
+                    menu_active = True # next char will be for menu
+                elif c == '\x02' or  c == '\x12': # ctrl+b/ctrl+r sendbreak
+                    console_print('[RESET]')
+                    cdc_reset(term.serial)
+                elif c == '\x03' or c == '\x1d': # ctrl+c/ctrl+]
+                    console_print('[QUIT]')
+                    term.stop()
+                    term.alive = False
+                    break
+                elif c == '\x05': # ctrl+e
+                    console_print('[ECHO %s]' % ('OFF' if term.echo else 'ON'))
+                    term.echo = not term.echo
+                elif c == '\x08': # ctrl+e
+                    print term.get_help_text()
+                elif c == '\t': # tab/ctrl+i
+                    term.dump_port_settings()
+                else:
+                    text = c
+                    for transformation in term.tx_transformations:
+                        text = transformation.tx(text)
+                    term.serial.write(term.tx_encoder.encode(text))
+                    if term.echo:
+                        echo_text = c
+                        for transformation in term.tx_transformations:
+                            echo_text = transformation.echo(echo_text)
+                        term.console.write(echo_text)
+        term.writer = input_handler
+
+        if print_term_header:
+            console_print('Terminal on {p.name} - {p.baudrate},{p.bytesize},{p.parity},{p.stopbits}'.format(p=term.serial))
+            console_print('Quit: CTRL+C | Reset: CTRL+B | Echo: CTRL+E')
+            console_print('Info: TAB    | Help:  Ctrl+H | Menu: Ctrl+T')
+
+        term.start()
+
+        try:
+            term.join(True)
+        except KeyboardInterrupt:
+            pass
+        term.join()
+        term.close()
+
+
+    result = False
+    serial_port = get_instance(port, baudrate=baudrate, timeout=timeout)
+    if serial_port:
+        serial_port.reset_input_buffer()
+        if reset:
+            cdc_reset(serial_port)
+            result = True
+
+        if sterm:
+            if not serial_port.is_open:
+                serial_port = get_instance(port, baudrate=baudrate, timeout=timeout)
+            try:
+                cdc_term(serial_port)
+                result = True
+            except:
+                pass
+
+    return result

--- a/mbed/mbed_cdc.py
+++ b/mbed/mbed_cdc.py
@@ -1,7 +1,11 @@
-from serial import Serial, SerialException
-import serial.tools.miniterm as miniterm
 
-def mbed_cdc(port, reset=False, sterm=False, baudrate=9600, timeout=10, print_term_header=True):
+def mbed_cdc(port, reset=False, sterm=False, baudrate=9600, timeout= 10, print_term_header=True):
+    try:
+        from serial import Serial, SerialException
+        import serial.tools.miniterm as miniterm
+    except (IOError, ImportError, OSError):
+        return False
+
     def get_instance(*args, **kwargs):
         try:
             serial_port = Serial(*args, **kwargs)

--- a/mbed/mbed_cdc.py
+++ b/mbed/mbed_cdc.py
@@ -1,4 +1,24 @@
 
+#!/usr/bin/env python2
+
+# Copyright (c) 2016 ARM Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+
+
+# pylint: disable=too-many-arguments, too-many-locals, too-many-branches, too-many-lines, line-too-long,
+# pylint: disable=too-many-nested-blocks, too-many-public-methods, too-many-instance-attributes, too-many-statements
+# pylint: disable=invalid-name, missing-docstring, bad-continuation
+
 def mbed_cdc(port, reset=False, sterm=False, baudrate=9600, timeout= 10, print_term_header=True):
     try:
         from serial import Serial, SerialException
@@ -22,7 +42,8 @@ def mbed_cdc(port, reset=False, sterm=False, baudrate=9600, timeout= 10, print_t
             try:
                 serial_instance.setBreak(False) # For Linux the following setBreak() is needed to release the reset signal on the target mcu.
             except:
-                result = False
+                return False
+        return True
 
     def cdc_term(serial_instance):
         term = miniterm.Miniterm(serial_instance, echo=True)
@@ -90,21 +111,21 @@ def mbed_cdc(port, reset=False, sterm=False, baudrate=9600, timeout= 10, print_t
         term.join()
         term.close()
 
+        return True
+
 
     result = False
     serial_port = get_instance(port, baudrate=baudrate, timeout=timeout)
     if serial_port:
         serial_port.reset_input_buffer()
         if reset:
-            cdc_reset(serial_port)
-            result = True
+            result = cdc_reset(serial_port)
 
         if sterm:
             if not serial_port.is_open:
                 serial_port = get_instance(port, baudrate=baudrate, timeout=timeout)
             try:
-                cdc_term(serial_port)
-                result = True
+                result = cdc_term(serial_port)
             except:
                 pass
 


### PR DESCRIPTION
**Revised based on feedback in #650 and #652**

This PR adds serial terminal feature to Mbed CLI via `mbed sterm` command. Currently, the supported command-line arguments are:
* `--port <COM port>` to specify system COM port to connect to.
* `--baudrate <numeric>` to select the communication baudrate, where the default value is 9600.
* `--echo <on|off>` to switch local echo (default is `on`).
* `--reset` to reset the connected target by sending Break before opening the serial terminal.

If no COM port is specified, Mbed CLI will attempt to detect the connected Mbed target and its COM port.

Inside the serial terminal, there's a wider variety of options:
```
--- CTRL+B     Send Break (reset target)
--- CTRL+C     Exit terminal
--- CTRL+E     Toggle local echo
--- CTRL+H     Help
--- CTRL+T     Menu escape key, followed by:
---    P       Change COM port
---    B       Change baudrate
---    TAB     Show detailed terminal info
---    CTRL+A  Change encoding (default UTF-8)
---    CTRL+F  Edit filters
---    CTRL+L  Toggle EOL
---    CTRL+R  Toggle RTS
---    CTRL+D  Toggle DTR
---    CTRL+C  Send control character to remote
---    CTRL+T  Send control character to remote
```

**Example usage with `mbed sterm`**
```
$ mbed sterm -r -b 115200
[mbed] Detecting connected targets/boards to your system...
[mbed] Opening serial terminal to "DISCO_L475VG_IOT01A"
--- Terminal on /dev/tty.usbmodem1413 - 115200,8,N,1 ---
$$$076402216E3C651F5178F3460x10000188
Start Simple Mbed Cloud Client
Connecting to the network using Wifi...
```

This feature also extends the `mbed compile` command and adds `--sterm` argument, which could be combined with `-f/--flash`. This enables automation workflow where Mbed CLI will first compile a program, then flash/apply it onto the connected target, and then open serial terminal to the target, so you can check the output of the freshly compiled program - see below.

```
$ mbed compile -t GCC_ARM -m DETECT -f --sterm
Building project mbed-os-example-blinky (DISCO_L475VG_IOT01A, GCC_ARM)
Scan: .
Scan: mbed
Scan: env
Compile [100.0%]: main.cpp
Link: mbed-os-example-blinky
Elf2Bin: mbed-os-example-blinky
+------------------+-------+-------+------+
| Module           | .text | .data | .bss |
+------------------+-------+-------+------+
| [fill]           |   102 |     7 |   11 |
| [lib]/c.a        | 27166 |  2204 |   56 |
| [lib]/gcc.a      |  3752 |     0 |    0 |
| [lib]/m.a        |    88 |     0 |    0 |
| [lib]/misc       |   236 |    16 |   28 |
| main.o           |   267 |     4 |  276 |
| mbed-os/drivers  |  1301 |     4 |  100 |
| mbed-os/hal      |  1395 |     4 |   66 |
| mbed-os/platform |  3096 |     4 |  354 |
| mbed-os/rtos     |  9114 |   168 | 5989 |
| mbed-os/targets  |  7017 |     5 |  388 |
| Subtotals        | 53534 |  2416 | 7268 |
+------------------+-------+-------+------+
Total Static RAM memory (data + bss): 9684 bytes
Total Flash memory (text + data): 55950 bytes

Image: ./BUILD/DISCO_L475VG_IOT01A/GCC_ARM/mbed-os-example-blinky.bin
[mbed] Detecting connected targets/boards to your system...
[mbed] Opening serial terminal to "DISCO_L475VG_IOT01A"
--- Terminal on /dev/tty.usbmodem1413 - 115200,8,N,1 ---
$$$07200221061A657F395EF362start
something 1
something 2
something 3
```

The implementation is based on PySerial, which is one of the fundamental libraries for Mbed Greentea (`mbed test`). Therefore there are no additional dependencies.

Inspired by @yennster's request (#639).
Also revised based on feedback in #650 and #652
