### PR TITLE
Fix missing izip import

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -42,7 +42,7 @@ import shutil
 import stat
 import errno
 import ctypes
-from itertools import chain, repeat
+from itertools import chain, izip, repeat
 import argparse
 import tempfile
 import zipfile
@@ -2484,7 +2484,7 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
               + list(chain.from_iterable(zip(repeat('--profile'), profile or [])))
               + list(chain.from_iterable(zip(repeat('--source'), source)))
               + (['-v'] if verbose else [])
-              + (list(chain.from_iterable(izip(repeat('--prefix'), config_prefix))) if config_prefix else []),
+              + (list(chain.from_iterable(zip(repeat('--prefix'), config_prefix))) if config_prefix else []),
               env=env)
     else:
         # If the user hasn't supplied a build directory, ignore the default build directory


### PR DESCRIPTION
After @cmonr broke this in the incomplete patch https://github.com/ARMmbed/mbed-cli/commit/6ad11b04a1b353118cdfb2ec8aa86873dba9b7d7#diff-dad37ed6e3ea3a963df6ff7090c2562f


Note that I love the mbed environment, except for the mbed-cli tooling. It is a pain in the ass and seems to break every time I update.