### PR TITLE
Added warning message about Mbed OS Py3 compatability

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2989,7 +2989,7 @@ def main():
 
     # Python 3 backwards compatability warning
     if sys.version_info[0] == 3:
-        warning("Usage of Python 3 requires Mbed OS >= v5.9")
+        warning("If you're using Python 3 with Mbed OS 5.8 and earlier versions, Python errors will occur when compiling, testing and exporting")
 
     pargs, remainder = parser.parse_known_args()
     status = 1

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2987,6 +2987,10 @@ def main():
         log(ver+"\n")
         sys.exit(0)
 
+    # Python 3 backwards compatability warning
+    if sys.version_info[0] == 3:
+        warning("Usage of Python 3 requires Mbed OS >= v5.9")
+
     pargs, remainder = parser.parse_known_args()
     status = 1
 


### PR DESCRIPTION
New output:
```
$ mbed new .
[mbed] WARNING: Usage of Python 3 requires Mbed OS >= v5.9
---
[mbed] Creating new program "test" (git)
[mbed] Adding library "mbed-os" from "ssh://git@github.com/ARMmbed/mbed-os" at branch/tag "latest"
...
```