### PR TITLE
Modifed Python 3 warning to only print after an Exception occurs.

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -3013,6 +3013,11 @@ def main():
         if very_verbose:
             traceback.print_exc(file=sys.stdout)
         error("Unknown Error: %s" % e, 255)
+    finally:
+        # Warn user if Python 3 might have caused an exception.
+        if status and sys.version_info[0] == 3:
+            warning("Using Python 3 with Mbed OS 5.8 and earlier can cause errors with compiling, testing and exporting");
+
     sys.exit(status or 0)
 
 


### PR DESCRIPTION
Sample output:

```
$ mbed export --ide GCC_ARM -m K64F --clean
Scan: .
Scan: FEATURE_LWIP
Scan: FEATURE_STORAGE
Traceback (most recent call last):
  File "/home/mrcruz/Work/py3-compat-porting/mbed-os-example-blinky/mbed-os/tools/project.py", line 286, in <module>
    main()
  File "/home/mrcruz/Work/py3-compat-porting/mbed-os-example-blinky/mbed-os/tools/project.py", line 281, in main
    ignore=options.ignore)
  File "/home/mrcruz/Work/py3-compat-porting/mbed-os-example-blinky/mbed-os/tools/project.py", line 102, in export
    app_config=app_config, ignore=ignore)
  File "/home/mrcruz/Work/py3-compat-porting/mbed-os-example-blinky/mbed-os/tools/export/__init__.py", line 304, in export_project
    macros=macros)
  File "/home/mrcruz/Work/py3-compat-porting/mbed-os-example-blinky/mbed-os/tools/export/__init__.py", line 161, in generate_project_files
    exporter.generate()
  File "/home/mrcruz/Work/py3-compat-porting/mbed-os-example-blinky/mbed-os/tools/export/makefile/__init__.py", line 130, in generate
    ctx['asm_flags'][index] = "-I" + ctx['vpath'][0] + "/" + ctx['asm_flags'][index][2:]
TypeError: 'map' object is not subscriptable
[mbed] ERROR: "/home/mrcruz/.local/share/virtualenvs/py3-env-nlIi979J/bin/python3" returned error code 1.
[mbed] ERROR: Command "/home/mrcruz/.local/share/virtualenvs/py3-env-nlIi979J/bin/python3 -u /home/mrcruz/Work/py3-compat-porting/mbed-os-example-blinky/mbed-os/tools/project.py -i gcc_arm -m K64F -c --source ." in "/home/mrcruz/Work/py3-compat-porting/mbed-os-example-blinky"
---
[mbed] WARNING: Using Python 3 with Mbed OS 5.8 and earlier can cause errors with compiling, testing and exporting
---
```

If we want it. My feelings won't be hurt if we decide to do the 1.7.3 release without it :)