### PR TITLE
Use relative paths for source and build dirs when testing

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2589,12 +2589,12 @@ def test_(toolchain=None, target=None, compile_list=False, run_list=False, compi
     with cd(program.path):
         # Setup the source path if not specified
         if not source or len(source) == 0:
-            source = [program.path]
+            source = [os.path.relpath(program.path, orig_path)]
 
         # Setup the build path if not specified
         build_path = build
         if not build_path:
-            build_path = os.path.join(program.path, program.build_dir, 'tests', target.upper(), tchain.upper())
+            build_path = os.path.join(os.path.relpath(program.path, orig_path), program.build_dir, 'tests', target.upper(), tchain.upper())
 
         if test_spec:
             # Preserve path to given test spec


### PR DESCRIPTION
This was discovered when doing some investigation for https://github.com/ARMmbed/mbed-os/issues/6861.

Currently, `mbed test` is passing absolute paths for the `--source` and `--build` options. This path is not shortened by the Mbed OS tools when compiling, so the include paths are much longer than they need to be. This alters `mbed test` to instead pass relative paths to both `--source` and `--build`.

While this won't fix the issue completely, it will drastically reduce the include path lengths when using `mbed test`.

*Steps to reproduce**

Before this patch, if you run `mbed test -m NRF52_DK -t GCC_ARM` in the root of `mbed-os` at commit `ed9a1f1327f5208fd462c5a6938696ee15e393f1` (recent commit off master branch), it will immediately fail to compile.

After applying this patch, you will be able to compile and test.