### PR TITLE
per profile build dirs

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2433,7 +2433,7 @@ def status_(ignore=False):
                 status_(ignore)
 
 
-# Helper function for compile subcommand
+# Helper function for compile and test subcommands
 def _safe_append_profile_to_build_path(build_path, profile):
     if profile:
         # profile is (or can be) a list, so just get the first element
@@ -2614,6 +2614,7 @@ def test_(toolchain=None, target=None, compile_list=False, run_list=False, compi
         build_path = build
         if not build_path:
             build_path = os.path.join(os.path.relpath(program.path, orig_path), program.build_dir, 'tests', target.upper(), tchain.upper())
+            build_path = _safe_append_profile_to_build_path(build_path, profile)
 
         if test_spec:
             # Preserve path to given test spec

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2442,7 +2442,7 @@ def _safe_append_profile_to_build_path(build_path, profile):
 
     if profile:
         profile_name_without_extension = os.path.splitext(os.path.basename(profile))[0].upper()
-        build_path += '__' + profile_name_without_extension
+        build_path += '-' + profile_name_without_extension
 
     return build_path
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2433,6 +2433,21 @@ def status_(ignore=False):
                 status_(ignore)
 
 
+# Helper function for compile subcommand
+def _safe_append_profile_to_build_path(build_path, profile):
+    append_str = 'DEFAULT'
+
+    if profile:
+        if isinstance(profile, basestring):
+            append_str = profile
+        else:
+            append_str = profile[0]
+
+    build_path = os.path.join(build_path, os.path.splitext(os.path.basename(append_str))[0].upper())
+
+    return build_path
+
+
 # Compile command which invokes the mbed OS native build system
 @subcommand('compile',
     dict(name=['-t', '--toolchain'], help='Compile toolchain. Example: ARM, GCC_ARM, IAR'),
@@ -2501,6 +2516,7 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
             # Compile as a library (current dir is default)
             if not build_path:
                 build_path = os.path.join(os.path.relpath(program.path, orig_path), program.build_dir, 'libraries', os.path.basename(orig_path), target.upper(), tchain.upper())
+                build_path = _safe_append_profile_to_build_path(build_path, profile)
 
             popen([python_cmd, '-u', os.path.join(tools_dir, 'build.py')]
                   + list(chain.from_iterable(zip(repeat('-D'), macros)))
@@ -2517,6 +2533,7 @@ def compile_(toolchain=None, target=None, profile=False, compile_library=False, 
             # Compile as application (root is default)
             if not build_path:
                 build_path = os.path.join(os.path.relpath(program.path, orig_path), program.build_dir, target.upper(), tchain.upper())
+                build_path = _safe_append_profile_to_build_path(build_path, profile)
 
             popen([python_cmd, '-u', os.path.join(tools_dir, 'make.py')]
                   + list(chain.from_iterable(zip(repeat('-D'), macros)))

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2435,15 +2435,14 @@ def status_(ignore=False):
 
 # Helper function for compile subcommand
 def _safe_append_profile_to_build_path(build_path, profile):
-    append_str = 'DEFAULT'
+    if profile:
+        # profile is (or can be) a list, so just get the first element
+        if not isinstance(profile, basestring):
+            profile = profile[0]
 
     if profile:
-        if isinstance(profile, basestring):
-            append_str = profile
-        else:
-            append_str = profile[0]
-
-    build_path = os.path.join(build_path, os.path.splitext(os.path.basename(append_str))[0].upper())
+        profile_name_without_extension = os.path.splitext(os.path.basename(profile))[0].upper()
+        build_path += '__' + profile_name_without_extension
 
     return build_path
 


### PR DESCRIPTION
# Summary

Attempt to address #615.

When a build dir is not specified, `mbed compile` creates a new per-build-profile subdirectory. This prevents full rebuilds when switching build profiles.

| Command                                                       | Build Dir                                          |
| ------------------------------------------------------------- | -------------------------------------------------- |
| `mbed compile`                                                | `BUILD/<target>/<toolchain>/DEFAULT/`              |
| `mbed compile --profile debug`                                | `BUILD/<target>/<toolchain>/DEBUG/`                |
| `mbed compile --profile=myprofiles/superoptimized-cpp11.json` | `BUILD/<target>/<toolchain>/SUPEROPTIMIZED-CPP11/` |
| `mbed compile --library --profile debug`                      | `BUILD/libraries/<project-name>/<target>/<toolchain>/DEBUG/` |


# Notes

1. My Python knowledge is limited, so there may be better ways to do things, or more error handling required, etc.
2. I'd be happy with lower case, but followed what seems to be the convention (upper case) here. Feel free to change it.

# Questions

1. Are there any programs or scripts that consume builds, which would need their code or paths updated?
2. Other concerns?