### PR TITLE
Correcting export directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ For example, to export to uVision, run:
 $ mbed export -i uvision -m K64F
 ```
 
-Mbed CLI creates a `.uvprojx` file in the projectfiles/uvision folder. You can open the project file with uVision.
+Mbed CLI creates a `.uvprojx` file in the root project directory. You can open the project file with uVision.
 
 ### Serial terminal
 


### PR DESCRIPTION
Just stumbled upon this little issue in the README. Exported project files have been placed in the root project directory for some time now.

FYI @theotherjimmy 