### PR TITLE
Allow downstream impl of `mbed dm` to print help

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2822,6 +2822,7 @@ def test_(toolchain=None, target=None, compile_list=False, run_list=False,
     dict(name='--build', help='Build directory. Default: build/'),
     dict(name='--source', action='append', help='Source directory. Default: . (current dir)'),
     help='device management supcommand',
+    add_help=False,
     hidden_aliases=['dev-mgmt', 'dm'],
     description=("Manage Device with Pelion"))
 def dev_mgmt(toolchain=None, target=None, source=False, profile=False, build=False):


### PR DESCRIPTION
The mbed dm subcommand has a complicated invocation. Instead of
duplicated the argument parser, I elected to pass the implementation
of `mbed dm --help` to the "downsteam implementation" (the python 
script in mbed-os).

Resolves help issues in https://github.com/ARMmbed/mbed-cli/issues/747