### PR TITLE
Fix: Caching thread safety

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -45,6 +45,7 @@ import ctypes
 from itertools import chain, repeat
 import time
 import zipfile
+import argparse
 from random import randint
 
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1409,17 +1409,20 @@ class Repo(object):
 
         lock_dir = os.path.join(cpath, '.lock')
         lock_file = os.path.join(lock_dir, 'pid')
-        if os.path.exists(lock_dir):
-            if os.path.isfile(lock_file):
-                try:
-                    with open(lock_file, 'r', 0) as f:
-                        pid = f.read(8)
-                    if int(pid) != os.getpid():
-                        error("Cache lock file exists with a different pid (\"%s\" vs \"%s\")" % (pid, os.getpid()))
-                except OSError:
-                    error("Unable to unlock cache dir \"%s\"" % (cpath))
-                os.remove(lock_file)
-            os.rmdir(lock_dir)
+        try:
+            if os.path.exists(lock_dir):
+                if os.path.isfile(lock_file):
+                    try:
+                        with open(lock_file, 'r', 0) as f:
+                            pid = f.read(8)
+                        if int(pid) != os.getpid():
+                            error("Cache lock file exists with a different pid (\"%s\" vs \"%s\")" % (pid, os.getpid()))
+                    except OSError:
+                        error("Unable to unlock cache dir \"%s\"" % (cpath))
+                    os.remove(lock_file)
+                os.rmdir(lock_dir)
+        except (OSError) as e:
+            pass
         return True
 
     def pid_exists(self, pid):

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1378,7 +1378,7 @@ class Repo(object):
                         f.flush()
                         os.fsync(f)
                     break
-                except (OSError, WindowsError) as e:
+                except (OSError) as e:
                     ## Windows:  
                     ##   <type 'exceptions.WindowsError'>    17 [Error 183] Cannot create a file when that file already exists: 'testing'
                     ##   or when concurrent:                 13 WindowsError(5, 'Access is denied')

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1356,7 +1356,7 @@ class Repo(object):
                     if os.path.isfile(lock_file):
                         try:
                             # lock file exists, but we need to check pid as well in case the process died
-                            with open(lock_file, 'r') as f:
+                            with open(lock_file, 'r', 0) as f:
                                 pid = f.read(8)
                             if pid and int(pid) != os.getpid():
                                 if self.pid_exists(pid):
@@ -1373,8 +1373,10 @@ class Repo(object):
                     break
 
                 if can_lock:
-                    with open(lock_file, 'wb') as f:
+                    with open(lock_file, 'wb', 0) as f:
                         f.write(str(os.getpid()))
+                        f.flush()
+
                 else:
                     error("Exceeded 5 minutes limit while waiting for other process to finish caching")
             except Exception:
@@ -1387,7 +1389,7 @@ class Repo(object):
             lock_file = os.path.join(cpath, '.lock')
             if os.path.isfile(lock_file):
                 try:
-                    with open(lock_file) as f:
+                    with open(lock_file, 'r', 0) as f:
                         pid = f.read(8)
                     if int(pid) == os.getpid():
                         os.remove(lock_file)

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1352,12 +1352,10 @@ class Repo(object):
         lock_dir = os.path.join(cpath, '.lock')
         lock_file = os.path.join(lock_dir, 'pid')
 
-        # this loop is handling a lock file from another process if exists
         for i in range(300): 
             if i:
                 time.sleep(1)
 
-            # lock file exists, but we need to check pid as well in case the process died
             if os.path.exists(lock_dir):
                 if os.path.isfile(lock_file):
                     with open(lock_file, 'r', 0) as f:
@@ -1399,6 +1397,7 @@ class Repo(object):
         cpath = self.url2cachedir(url)
         if not cpath:
             return False
+
         lock_dir = os.path.join(cpath, '.lock')
         lock_file = os.path.join(lock_dir, 'pid')
         if os.path.exists(lock_dir):

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -3329,6 +3329,7 @@ def main():
                 "You could retry the last command with \"-v\" flag for verbose output\n", e.args[0])
         else:
             error('OS Error: %s' % e.args[1], e.args[0])
+        traceback.print_exc(file=sys.stdout)
     except KeyboardInterrupt:
         info('User aborted!', -1)
         sys.exit(255)

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1358,23 +1358,26 @@ class Repo(object):
                 time.sleep(1)
 
             if os.path.exists(lock_dir):
-                if os.path.isfile(lock_file):
-                    with open(lock_file, 'r', 0) as f:
-                        pid = f.read(8)
-                    if not pid:
-                        if int(os.path.getmtime(lock_file)) + timeout < int(time.time()):
-                            info("Cache lock file exists, but is empty. Cleaning up")
+                try:
+                    if os.path.isfile(lock_file):
+                        with open(lock_file, 'r', 0) as f:
+                            pid = f.read(8)
+                        if not pid:
+                            if int(os.path.getmtime(lock_file)) + timeout < int(time.time()):
+                                info("Cache lock file exists, but is empty. Cleaning up")
+                                os.remove(lock_file)
+                                os.rmdir(lock_dir)
+                        elif int(pid) != os.getpid() and self.pid_exists(pid):
+                            info("Cache lock file exists and process %s is alive." % pid)
+                        else:
+                            info("Cache lock file exists, but %s is dead. Cleaning up" % pid)
                             os.remove(lock_file)
                             os.rmdir(lock_dir)
-                    elif int(pid) != os.getpid() and self.pid_exists(pid):
-                        info("Cache lock file exists and process %s is alive." % pid)
                     else:
-                        info("Cache lock file exists, but %s is dead. Cleaning up" % pid)
-                        os.remove(lock_file)
                         os.rmdir(lock_dir)
-                else:
-                    os.rmdir(lock_dir)
-                continue
+                    continue
+                except (OSError) as e:
+                    continue
             else:
                 try:
                     os.mkdir(lock_dir)

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -42,6 +42,7 @@ import shutil
 import stat
 import errno
 import ctypes
+from itertools import chain, repeat
 import time
 import zipfile
 import argparse


### PR DESCRIPTION
This aims to fix caching thread safety in Mbed CLI. It uses directory creation which is atomic operation on all operating systems. I've tested with the script @adamelhakham wrote. Additionally @adamelhakham tested it in their CI. I'd still advise to try it in staging CI rather than live.
Addresses https://github.com/ARMmbed/mbed-cli/issues/660

CC @teetak01 @yogpan01 