### PR TITLE
Release v1.8.1

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -51,7 +51,7 @@ from contextlib import contextmanager
 
 
 # Application version
-ver = '1.8.0'
+ver = '1.8.1'
 
 # Default paths to Mercurial and Git
 hg_cmd = 'hg'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="mbed-cli",
-    version="1.8.0",
+    version="1.8.1",
     description="Arm Mbed command line tool for repositories version control, publishing and updating code from remotely hosted repositories (GitHub, GitLab and mbed.com), and invoking Mbed OS own build system and export functions, among other operations",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
**Fixed:**
* Concurrent Mbed CLI deploys that access the same cached repo no longer cause cache corruption.
* Python dependencies using a github url and release instead of a package name and version are checked correctly and no longer cause sperious pip installs.
* `mbed test --unittest` no longer requires a target and toolchain, which it simply throws away.