### PR TITLE
Return None from MbedTerminal Constructor

### DIFF
--- a/mbed/mbed_terminal.py
+++ b/mbed/mbed_terminal.py
@@ -35,7 +35,8 @@ class MbedTerminal(object):
         try:
             from serial import Serial, SerialException
         except (IOError, ImportError, OSError):
-            return False
+            self.serial = None
+            return
 
         try:
             self.serial = Serial(self.port, baudrate=self.baudrate, timeout=self.timeout)
@@ -43,7 +44,7 @@ class MbedTerminal(object):
             self.serial.reset_input_buffer()
         except Exception as e:
             self.serial = None
-            return False
+            return
 
     def terminal(self, print_header=True):
         try:

--- a/mbed/mbed_terminal.py
+++ b/mbed/mbed_terminal.py
@@ -34,15 +34,10 @@ class MbedTerminal(object):
 
         try:
             from serial import Serial, SerialException
-        except (IOError, ImportError, OSError):
-            self.serial = None
-            return
-
-        try:
             self.serial = Serial(self.port, baudrate=self.baudrate, timeout=self.timeout)
             self.serial.flush()
             self.serial.reset_input_buffer()
-        except Exception as e:
+        except (IOError, ImportError, OSError, Exception):
             self.serial = None
             return
 


### PR DESCRIPTION
Since we examine `self.serial` to determine the success of the 
constructor, I made all `return False` statements within the constructor
set `self.serial = None`. That way the current code should catch the
failures without any additional changes

Fixes #688