### PR TITLE
Use bytes or %r to handle paths and process output

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -156,7 +156,10 @@ _cwd = os.getcwd()
 
 # Logging and output
 def log(msg, is_error=False):
-    sys.stderr.write(msg) if is_error else sys.stdout.write(msg)
+    if sys.version_info[0] > 2 and isinstance(msg, bytes):
+        sys.stderr.buffer.write(msg) if is_error else sys.stdout.buffer.write(msg)
+    else:
+        sys.stderr.write(msg) if is_error else sys.stdout.write(msg)
 
 def message(msg):
     if very_verbose:

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -274,7 +274,7 @@ def pquery(command, output_callback=None, stdin=None, **kwargs):
     stdout, _ = proc.communicate(stdin)
 
     if very_verbose:
-        log(stdout.strip() + "\n")
+        log(stdout.strip() + b'\n')
 
     if proc.returncode != 0:
         raise ProcessException(proc.returncode, command[0], ' '.join(command), getcwd())


### PR DESCRIPTION
Paths are not ASCII, paths are not Unicode. Paths are bytes.
This PR handles paths like they are bytes, well at least the 
current working directory. Handling paths and process output as
if they are unicode will introduce errors when paths are not 
valid unicode. I tested this by creating a directory named
    
    �abc\uXXXX

Which is not valid unicode, and tricks most python string 
decoders into throwing an exception.

Fixes #710, maybe