### PR TITLE
Feature: Improve awareess about current path and current program/project

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1133,6 +1133,9 @@ class Repo(object):
 
     @classmethod
     def isinsecure(cls, url):
+        path = re.sub(r'^(.+)[#?].*$', r'\1', url)
+        if os.path.isdir(path): # local paths are secure
+            return False
         up = urlparse(url)
         return (not up) or (up.scheme and up.scheme not in ['http', 'https', 'ssh', 'git']) or (up.port and int(up.port) not in [22, 80, 443])
 

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -3344,7 +3344,10 @@ def main():
     try:
         very_verbose = pargs.very_verbose
         verbose = very_verbose or pargs.verbose
-        info('Working path \"%s\" (%s)' % (getcwd(), Repo.pathtype(cwd_root)))
+        pathtype = Repo.pathtype(cwd_root)
+        action('Working path \"%s\" (%s)' % (cwd_root, pathtype))
+        if pathtype != "program":
+            action('Program path \"%s\"' % Program(cwd_root).path)
         status = pargs.command(pargs)
     except ProcessException as e:
         error(

--- a/test/add_test.py
+++ b/test/add_test.py
@@ -20,7 +20,7 @@ def test_add(mbed, testrepos):
         popen(['python', mbed, 'add', test3, "-vv"])
 
     assertls(mbed, 'test1', [
-        "*",
+        "[mbed]",
         "test1",
         "|- test2",
         "|  `- test3",
@@ -38,7 +38,7 @@ def test_import_after_add(mbed, testrepos):
     popen(['python', mbed, 'import', test1, 'testimport', "-vv"])
 
     assertls(mbed, 'testimport', [
-        "*",
+        "[mbed]",
         "testimport",
         "|- test2",
         "|  `- test3",

--- a/test/add_test.py
+++ b/test/add_test.py
@@ -20,6 +20,7 @@ def test_add(mbed, testrepos):
         popen(['python', mbed, 'add', test3, "-vv"])
 
     assertls(mbed, 'test1', [
+        "*",
         "test1",
         "|- test2",
         "|  `- test3",
@@ -37,6 +38,7 @@ def test_import_after_add(mbed, testrepos):
     popen(['python', mbed, 'import', test1, 'testimport', "-vv"])
 
     assertls(mbed, 'testimport', [
+        "*",
         "testimport",
         "|- test2",
         "|  `- test3",

--- a/test/import_test.py
+++ b/test/import_test.py
@@ -18,7 +18,7 @@ def test_import(mbed, testrepos):
     popen(['python', mbed, 'import', test1, 'testimport'])
 
     assertls(mbed, 'testimport', [
-        "*",
+        "[mbed]",
         "testimport",
         "`- test2",
         "   `- test3",

--- a/test/import_test.py
+++ b/test/import_test.py
@@ -18,6 +18,7 @@ def test_import(mbed, testrepos):
     popen(['python', mbed, 'import', test1, 'testimport'])
 
     assertls(mbed, 'testimport', [
+        "*",
         "testimport",
         "`- test2",
         "   `- test3",

--- a/test/ls_test.py
+++ b/test/ls_test.py
@@ -15,7 +15,7 @@ from util import *
 # Tests 'mbed ls' and provides sanity check of test framework
 def test_ls(mbed, testrepos):
     assertls(mbed, 'test1', [
-        "*",
+        "[mbed]",
         "test1",
         "`- test2",
         "   `- test3",

--- a/test/ls_test.py
+++ b/test/ls_test.py
@@ -15,6 +15,7 @@ from util import *
 # Tests 'mbed ls' and provides sanity check of test framework
 def test_ls(mbed, testrepos):
     assertls(mbed, 'test1', [
+        "*",
         "test1",
         "`- test2",
         "   `- test3",

--- a/test/remove_test.py
+++ b/test/remove_test.py
@@ -18,7 +18,7 @@ def test_remove(mbed, testrepos):
         popen(['python', mbed, 'remove', 'test2'])
 
     assertls(mbed, 'test1', [
-        "*",
+        "[mbed]",
         "test1",
     ])
 
@@ -31,6 +31,6 @@ def test_import_after_remove(mbed, testrepos):
     popen(['python', mbed, 'import', test1, 'testimport'])
 
     assertls(mbed, 'testimport', [
-        "*",
+        "[mbed]",
         "testimport",
     ])

--- a/test/remove_test.py
+++ b/test/remove_test.py
@@ -18,6 +18,7 @@ def test_remove(mbed, testrepos):
         popen(['python', mbed, 'remove', 'test2'])
 
     assertls(mbed, 'test1', [
+        "*",
         "test1",
     ])
 
@@ -30,5 +31,6 @@ def test_import_after_remove(mbed, testrepos):
     popen(['python', mbed, 'import', test1, 'testimport'])
 
     assertls(mbed, 'testimport', [
+        "*",
         "testimport",
     ])

--- a/test/sync_update_test.py
+++ b/test/sync_update_test.py
@@ -51,7 +51,7 @@ def test_sync_update_remove(mbed, testrepos):
         popen(['python', mbed, 'update', '-vv'])
 
     assertls(mbed, 'testimport', [
-        "*",
+        "[mbed]",
         "testimport",
         "`- test2",
     ])
@@ -74,7 +74,7 @@ def test_sync_update_add(mbed, testrepos):
         popen(['python', mbed, 'update', '-vv'])
 
     assertls(mbed, 'testimport', [
-        "*",
+        "[mbed]",
         "testimport",
         "`- test2",
         "   |- test3",
@@ -101,7 +101,7 @@ def test_sync_update_move(mbed, testrepos):
         popen(['python', mbed, 'update', '-vv'])
 
     assertls(mbed, 'testimport', [
-        "*",
+        "[mbed]",
         "testimport",
         "`- test2",
         "   `- testmove",

--- a/test/sync_update_test.py
+++ b/test/sync_update_test.py
@@ -51,6 +51,7 @@ def test_sync_update_remove(mbed, testrepos):
         popen(['python', mbed, 'update', '-vv'])
 
     assertls(mbed, 'testimport', [
+        "*",
         "testimport",
         "`- test2",
     ])
@@ -73,6 +74,7 @@ def test_sync_update_add(mbed, testrepos):
         popen(['python', mbed, 'update', '-vv'])
 
     assertls(mbed, 'testimport', [
+        "*",
         "testimport",
         "`- test2",
         "   |- test3",
@@ -99,6 +101,7 @@ def test_sync_update_move(mbed, testrepos):
         popen(['python', mbed, 'update', '-vv'])
 
     assertls(mbed, 'testimport', [
+        "*",
         "testimport",
         "`- test2",
         "   `- testmove",


### PR DESCRIPTION
This small PR aims to improve the awareness of the user about the current location and current program by adding output to every `mbed` command.

Here's an example:

```
D:\Work\smcc-tests\simple-mbed-cloud-client> mbed detect
[mbed] Working path "D:\Work\smcc-tests\simple-mbed-cloud-client" (library)
[mbed] Program path "D:\Work\smcc-tests"
[mbed] No mbed targets were detected on your system.
```

and also 

```
D:\Work\smcc-tests> mbed detect
[mbed] Working path "D:\Work\smcc-tests" (program)
[mbed] No mbed targets were detected on your system.
```