### PR TITLE
scm: fix new command only use hg to clone code

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -477,6 +477,9 @@ class Hg(object):
         return True
 
     def clone(url, name=None, depth=None, protocol=None):
+        if any(os.access(os.path.join(path, name), os.X_OK) for path in os.environ["PATH"].split(os.pathsep)) == False:
+            raise ProcessException(1, "hg file is not exist")
+
         if verbose or very_verbose:
             popen([hg_cmd, 'clone', formaturl(url, protocol), name] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
         else:


### PR DESCRIPTION
add check is hg file exist or not to avoid never try to use git.
But this patch maybe only for python 3.x
