### PR TITLE
Add future dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(
             'mbed-cli=mbed.mbed:main',
         ]
     },
+    install_requires=[
+        'future'
+    ],
     python_requires='>=2.7.10,!=3.0.*,!=3.1.*,<4',
     classifiers=(
         "Programming Language :: Python :: 2",


### PR DESCRIPTION
The Python 2 tests are currently failing for all PRs because mbed-cli uses the `builtins` module that comes with the `future` package. This was not listed in the `install_requires`, so I've added it.

FYI @screamerbg @theotherjimmy