### PR TITLE
Fix: Add --force flag to `git fetch` to allow tags to be fetched in git 2.20

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -738,7 +738,7 @@ class Git(object):
 
     def publish(all_refs=None):
         if all_refs:
-            popen([git_cmd, 'push'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+            popen([git_cmd, 'push', '--all'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
         else:
             remote = Git.getremote()
             branch = Git.getbranch()
@@ -753,7 +753,7 @@ class Git(object):
 
     def fetch():
         info("Fetching revisions from remote repository to \"%s\"" % os.path.basename(getcwd()))
-        popen([git_cmd, 'fetch', '--tags', '--force'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+        popen([git_cmd, 'fetch', '--all', '--tags', '--force'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
 
     def discard(clean_files=False):
         info("Discarding local changes in \"%s\"" % os.path.basename(getcwd()))

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -738,7 +738,7 @@ class Git(object):
 
     def publish(all_refs=None):
         if all_refs:
-            popen([git_cmd, 'push', '--all'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+            popen([git_cmd, 'push'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
         else:
             remote = Git.getremote()
             branch = Git.getbranch()
@@ -753,7 +753,7 @@ class Git(object):
 
     def fetch():
         info("Fetching revisions from remote repository to \"%s\"" % os.path.basename(getcwd()))
-        popen([git_cmd, 'fetch', '--all', '--tags'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+        popen([git_cmd, 'fetch', '--tags', '--force'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
 
     def discard(clean_files=False):
         info("Discarding local changes in \"%s\"" % os.path.basename(getcwd()))


### PR DESCRIPTION
Add --force flag to `git fetch` to allow tags to be fetched in git 2.20+ (related to the moving 'latest' branch in Mbed OS).

Also limit the remote repos used during fetch and push to the default one (remove `--all` flag from `git push` and `git fetch`).

See https://github.com/ARMmbed/mbed-cli/issues/831#issuecomment-459670021