### PR TITLE
Feature: Macros handling to `mbed test`

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1760,7 +1760,7 @@ class Program(object):
         if toolchain and not self.get_cfg('TOOLCHAIN'):
             self.set_cfg('TOOLCHAIN', toolchain)
 
-    def get_macros(self, more_macros=False):
+    def get_macros(self, more_macros=None):
         macros = more_macros or []
         # backwards compatibility with old MACROS.txt file
         if os.path.isfile('MACROS.txt'):

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1760,7 +1760,8 @@ class Program(object):
         if toolchain and not self.get_cfg('TOOLCHAIN'):
             self.set_cfg('TOOLCHAIN', toolchain)
 
-    def get_macros(self, macros=[]):
+    def get_macros(self, more_macros=False):
+        macros = more_macros or []
         # backwards compatibility with old MACROS.txt file
         if os.path.isfile('MACROS.txt'):
             with open('MACROS.txt') as f:

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1765,7 +1765,7 @@ class Program(object):
         # backwards compatibility with old MACROS.txt file
         if os.path.isfile('MACROS.txt'):
             with open('MACROS.txt') as f:
-                macros = f.read().splitlines()
+                macros.extend(f.read().splitlines())
         return macros
 
 


### PR DESCRIPTION
This PR introduces 3 related features:
* Add support for macros handling to `mbed test`
* Pass macros only to `mbed-os/tools/test.py` and not to `mbedgt` to enable workflow where `mbed test ... -D SOME_MACRO` will both compile the tests with the macro and also run mbed greentea without getting the `no such option: -D` error.
* Add macro `MBED_TEST_MODE` to `mbed test` to allow the main application to exclude `main()`. See https://github.com/ARMmbed/pelion-ready-example/blob/master/main.cpp#L18