### PR TITLE
Do not force pelion host address if not present

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -3008,8 +3008,6 @@ def dev_mgmt(toolchain=None, target=None, source=False, profile=False, build=Fal
         args += (['--mcu', target] if target else [])
         args += (['--build', build_path] if build_path else [])
     env = program.get_env()
-    if "MBED_CLOUD_SDK_HOST" not in env:
-        env["MBED_CLOUD_SDK_HOST"] = "https://api.us-east-1.mbedcloud.com"
     popen([python_cmd, '-u', script]
           + args
           + list(chain.from_iterable(zip(repeat('--source'), source or []))),


### PR DESCRIPTION
This allows the pelion sdk to take care of the configuration of the host. Based on the git history, this commit was originally added to solve an issue that has since been resolved in the pelion sdk.
- mbed-cli commit: https://github.com/ARMmbed/mbed-cli/pull/735/commits/35f7b36bd384d740fe2b8a5e8e839a3ab516ac39
- Fix in version 2.0.1 of the sdk: https://github.com/ARMmbed/mbed-cloud-sdk-python/blob/master/CHANGELOG.rst#201-2018-09-07