### PR TITLE
Updated: Add --force flag to `git fetch` to allow tags to be fetched in git 2.20

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -738,7 +738,7 @@ class Git(object):
 
     def publish(all_refs=None):
         if all_refs:
-            popen([git_cmd, 'push'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+            popen([git_cmd, 'push', '--all'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
         else:
             remote = Git.getremote()
             branch = Git.getbranch()
@@ -753,7 +753,7 @@ class Git(object):
 
     def fetch():
         info("Fetching revisions from remote repository to \"%s\"" % os.path.basename(getcwd()))
-        popen([git_cmd, 'fetch', '--tags', '--force'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+        popen([git_cmd, 'fetch', '--all', '--tags', '--force'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
 
     def discard(clean_files=False):
         info("Discarding local changes in \"%s\"" % os.path.basename(getcwd()))

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -738,7 +738,7 @@ class Git(object):
 
     def publish(all_refs=None):
         if all_refs:
-            popen([git_cmd, 'push', '--all'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+            popen([git_cmd, 'push'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
         else:
             remote = Git.getremote()
             branch = Git.getbranch()
@@ -753,7 +753,7 @@ class Git(object):
 
     def fetch():
         info("Fetching revisions from remote repository to \"%s\"" % os.path.basename(getcwd()))
-        popen([git_cmd, 'fetch', '--all', '--tags'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
+        popen([git_cmd, 'fetch', '--tags', '--force'] + (['-v'] if very_verbose else ([] if verbose else ['-q'])))
 
     def discard(clean_files=False):
         info("Discarding local changes in \"%s\"" % os.path.basename(getcwd()))


### PR DESCRIPTION
This updates #824 by limiting the changes to just add the `--force` flag for compatibility with Git 2.20.