### PR TITLE
Fix mbed compile --flash

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2640,7 +2640,7 @@ def _safe_append_profile_to_build_path(build_path, profile):
 def compile_(toolchain=None, target=None, macro=False, profile=False,
              compile_library=False, compile_config=False, config_prefix=None,
              source=False, build=False, clean=False, flash=False, sterm=False,
-             artifact_name=None, supported=False, app_config=None):
+             baudrate=9600, artifact_name=None, supported=False, app_config=None):
     # Gather remaining arguments
     args = remainder
     # Find the root of the program


### PR DESCRIPTION
Unknown error is thrown while executing mbed compile --flash:

[mbed] ERROR: Unknown Error: local variable 'baudrate' referenced before assignment

Add the required argument to compile_ method.
This also fixes another error while mbed compile --flash --baudrate 9600:

[mbed] ERROR: Unknown Error: compile_() got an unexpected keyword argument 'baudrate'

This is a regression introduced by https://github.com/ARMmbed/mbed-cli/pull/837