### PR TITLE
Fix downloading of Mbed 2 when zip is too big

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -389,10 +389,13 @@ class Bld(object):
         try:
             if not os.path.exists(rev_file):
                 action("Downloading library build \"%s\" (might take a while)" % rev)
-                outfd = open(rev_file, 'wb')
                 inurl = urlopen(url)
-                outfd.write(inurl.read())
-                outfd.close()
+                with open(rev_file, 'wb') as outfd:
+                    data = None
+                    while data != '':
+                        # Download and write the data in 1 MB chunks
+                        data = inurl.read(1024 * 1024)
+                        outfd.write(data)
         except:
             if os.path.isfile(rev_file):
                 os.remove(rev_file)

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -396,7 +396,7 @@ class Bld(object):
                         # Download and write the data in 1 MB chunks
                         data = inurl.read(1024 * 1024)
                         outfd.write(data)
-        except:
+        except Exception:
             if os.path.isfile(rev_file):
                 os.remove(rev_file)
             raise Exception(128, "Download failed!\nPlease try again later.")


### PR DESCRIPTION
The Mbed 2 zip was being downloaded into memory. With the latest releases, my Windows machine failed to download it because it ran out of memory! This downloads the zip in 1 MB chunks then writes them to disk to avoid running out of memory.