### PR TITLE
Fix handling of non mbed .lib files in Python 3

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1051,8 +1051,11 @@ class Repo(object):
 
     @classmethod
     def fromlib(cls, lib=None):
-        with open(lib) as f:
-            ref = f.read(200)
+        try:
+            with open(lib) as f:
+                ref = f.read(200)
+        except UnicodeDecodeError:
+            ref = ""
 
         m_local = re.match(regex_local_ref, ref.strip().replace('\\', '/'))
         m_repo_ref = re.match(regex_url_ref, ref.strip().replace('\\', '/'))


### PR DESCRIPTION
This should fix #859.

Side question (to potentially follow up in another PR): @screamerbg reading only 200 characters here seems a bit low. Could we instead read until the first non-empty line?