### PR TITLE
Use input() instead of raw_input() for py3

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2326,7 +2326,10 @@ def publish(all_refs=None, msg=None, top=True):
         if msg:
             repo.commit(msg)
         else:
-            raw_input('Press enter to commit and publish: ')
+            if sys.version_info[0] == 3:
+                input('Press enter to commit and publish: ')
+            else:
+                raw_input('Press enter to commit and publish: ')
             repo.commit()
 
     try:


### PR DESCRIPTION
Here's an initial fix for #869.

Uses `sys.version_info` since that's used elsewhere in the script as well to differentiate python versions.