### PR TITLE
allow tag to be used in mbed import

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1062,7 +1062,7 @@ class Repo(object):
         if m_repo_ref:
             rev = m_repo_ref.group(3)
             if rev and not re.match(r'^([a-fA-F0-9]{6,40})$', rev):
-                error('named branches not allowed in .lib, offending lib is {} '.format(os.path.basename(lib)))
+                error('Named branches not allowed in .lib, offending lib is {} '.format(os.path.basename(lib)))
 
         if not (m_local or m_bld_ref or m_repo_ref):
             warning(

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1058,6 +1058,12 @@ class Repo(object):
         m_local = re.match(regex_local_ref, ref.strip().replace('\\', '/'))
         m_repo_ref = re.match(regex_url_ref, ref.strip().replace('\\', '/'))
         m_bld_ref = re.match(regex_build_url, ref.strip().replace('\\', '/'))
+
+        if m_repo_ref:
+            rev = m_repo_ref.group(3)
+            if rev and not re.match(r'^([a-fA-F0-9]{6,40})$', rev):
+                error('named branches not allowed in .lib, offending lib is {} '.format(os.path.basename(lib)))
+
         if not (m_local or m_bld_ref or m_repo_ref):
             warning(
                 "File \"%s\" in \"%s\" uses a non-standard .lib file extension, which is not compatible with the mbed build tools.\n" % (os.path.basename(lib), os.path.split(lib)[0]))

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1038,8 +1038,6 @@ class Repo(object):
             repo.path = os.path.abspath(path or os.path.join(getcwd(), repo.name))
             repo.url = formaturl(m_repo_ref.group(1))
             repo.rev = m_repo_ref.group(3)
-            if repo.rev and repo.rev != 'latest' and repo.rev != 'tip' and not re.match(r'^([a-fA-F0-9]{6,40})$', repo.rev):
-                error('Invalid revision (%s)' % repo.rev, -1)
         else:
             error('Invalid repository (%s)' % url.strip(), -1)
 


### PR DESCRIPTION
Fix  for  **IOTCORE-1104** 

Branching strategy is changing starting 5.12 for example.  `mbed import` currently doesn't allow the user to specify branches/tags. There was a check which explicitly restricting to import tags other than `latest` or `tip`  maybe there is some limitation.

This change will have minimal impact on user workflow they can continue using the same command

- Example for branch `mbed import https://github.com/ARMmbed/mbed-os-example-blinky#mbed-os-5.12 blinky-5-12 -vvv`  
- Example for tag  `mbed import https://github.com/ARMmbed/mbed-os-example-blinky#mbed-os-5.12.0-rc2 blinky-5-12-rc2 -vvv`  

@screamerbg can you please review it.

cc @theotherjimmy @bridadan @SenRamakri 
