### PR TITLE
Add requirements

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1817,23 +1817,20 @@ class Program(object):
 
     def get_detected_targets(self):
         targets = []
-        try:
-            import mbed_lstools
-            oldError = None
-            if os.name == 'nt':
-                oldError = ctypes.windll.kernel32.SetErrorMode(1) # Disable Windows error box temporarily. note that SEM_FAILCRITICALERRORS = 1
-            mbeds = mbed_lstools.create()
-            detect_muts_list = mbeds.list_mbeds()
-            if os.name == 'nt':
-                ctypes.windll.kernel32.SetErrorMode(oldError)
+        import mbed_os_tools.detect
+        oldError = None
+        if os.name == 'nt':
+            oldError = ctypes.windll.kernel32.SetErrorMode(1) # Disable Windows error box temporarily. note that SEM_FAILCRITICALERRORS = 1
+        mbeds = mbed_os_tools.detect.create()
+        detect_muts_list = mbeds.list_mbeds()
+        if os.name == 'nt':
+            ctypes.windll.kernel32.SetErrorMode(oldError)
 
-            for mut in detect_muts_list:
-                targets.append({
-                    'id': mut['target_id'], 'name': mut['platform_name'],
-                    'mount': mut['mount_point'], 'serial': mut['serial_port']
-                })
-        except (IOError, ImportError, OSError):
-            return False
+        for mut in detect_muts_list:
+            targets.append({
+                'id': mut['target_id'], 'name': mut['platform_name'],
+                'mount': mut['mount_point'], 'serial': mut['serial_port']
+            })
 
         return targets
 

--- a/setup.py
+++ b/setup.py
@@ -39,4 +39,8 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ),
+    install_requires=[
+        "pyserial>=3.0,<4.0",
+        "mbed-os-tools<0.1.0",
+    ]
 )


### PR DESCRIPTION
Fixes #880.

Both `pyserial` and `mbed-ls` (now using the `mbed-os-tools` package) are called directly by Mbed CLI, so let's add them as Python requirements.

Because `mbed-os-tools` is now a direct requirement, we can remove the `try/except` block to catch the import error.