### PR TITLE
Fix regression: Allow #tip and #latest tags in *.lib

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1061,7 +1061,7 @@ class Repo(object):
 
         if m_repo_ref:
             rev = m_repo_ref.group(3)
-            if rev and not re.match(r'^([a-fA-F0-9]{6,40})$', rev):
+            if rev and rev != 'latest' and rev != 'tip' and not re.match(r'^([a-fA-F0-9]{6,40})$', rev):
                 error('Named branches not allowed in .lib, offending lib is {} '.format(os.path.basename(lib)))
 
         if not (m_local or m_bld_ref or m_repo_ref):


### PR DESCRIPTION
PR#873 introduced a regression in *.lib file handling:
https://github.com/ARMmbed/mbed-cli/pull/873/files

Before 1.10.0, Mbed CLi was able to import components
from lib files with 'latest' or 'tip' tag as revision specifier:
https://github.com/ARMmbed/mbed-os/#latest

It is no longer possible with 1.10.0:
[mbed] ERROR: Named branches not allowed in .lib, offending lib is mbed-os.lib

This change brings back support for both tags in lib files.