### PR TITLE
Includes app_config when starting get_config.py

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2728,6 +2728,7 @@ def compile_(toolchain=None, target=None, macro=False, profile=False,
               + list(chain.from_iterable(zip(repeat('--profile'), profile or [])))
               + list(chain.from_iterable(zip(repeat('--source'), source)))
               + (['-v'] if verbose else [])
+              + (['--app-config', app_config] if app_config else [])
               + (list(chain.from_iterable(zip(repeat('--prefix'), config_prefix))) if config_prefix else []),
               env=env)
     else:


### PR DESCRIPTION
The get_config.py scripts supports providing the app_config
file path as an argument, but mbed.py does not include it,
when starting get_config.py, which means that the configuration
being built will differ from the output of get_config.py, when
building with an app_config != mbed_app.json.