### PR TITLE
Updated version to 1.10.1

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2016-2019 ARM Limited, All Rights Reserved
+# Copyright (c) 2016-2019 Arm Limited, All Rights Reserved
 # SPDX-License-Identifier: Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,7 +53,7 @@ from contextlib import contextmanager
 
 
 # Application version
-ver = '1.10.0'
+ver = '1.10.1'
 
 # Default paths to Mercurial and Git
 hg_cmd = 'hg'

--- a/setup.py
+++ b/setup.py
@@ -32,15 +32,20 @@ setup(
             'mbed-cli=mbed.mbed:main',
         ]
     },
-    python_requires='>=2.7.10,!=3.0.*,!=3.1.*,<4',
+    python_requires='>=2.7.10, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.0, !=3.4.1, !=3.4.2, <4',
     classifiers=(
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 3",
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ),
     install_requires=[
         "pyserial>=3.0,<4.0",
-        "mbed-os-tools<0.1.0",
+        "mbed-os-tools>=0.0.9,<0.1.0",
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 ARM Limited, All Rights Reserved
+# Copyright (c) 2016-2019 ARM Limited, All Rights Reserved
 # SPDX-License-Identifier: Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,12 +18,12 @@ with open("README.md", "r") as fh:
 
 setup(
     name="mbed-cli",
-    version="1.10.0",
+    version="1.10.1",
     description="Arm Mbed command line tool for repositories version control, publishing and updating code from remotely hosted repositories (GitHub, GitLab and mbed.com), and invoking Mbed OS own build system and export functions, among other operations",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url='http://github.com/ARMmbed/mbed-cli',
-    author='ARM mbed',
+    author='Arm mbed',
     author_email='support@mbed.org',
     packages=["mbed"],
     entry_points={


### PR DESCRIPTION
## Fixes
* Improved python-3 support
* #889 Removed a warning generated when parsing the python requirements file
* #890 Fix support for 'latest' and 'tip' tags in .lib files
* #896 Git now uses the branch that the cache was checked out to, rather than master, by default. This then follows the selection of 'default branch' as understood by github
* #903 Removed unsupported --profile option when calling get_config.py
* #907 get_config now reports the actual built config, even when app_config != mbed_app.json.

## New features
* #900 Improved warning messages around python-3 support.
* #884 Platform detection now uses mbedls rather than older detect code

## Other changes
* Now dependent on mbed-os-tools and pyserial
* Minimum version of Python now explicitly declared.
