### PR TITLE
Add dot to import in mbed/__main__.py to run as module

### DIFF
--- a/mbed/__main__.py
+++ b/mbed/__main__.py
@@ -1,2 +1,2 @@
-from mbed import main
+from .mbed import main
 main()


### PR DESCRIPTION
Running mbed as a module with python -m (to ensure it's running from virtualenv) with python3 causes the following:
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/juhpuur/mbed-cli/mbed/__main__.py", line 1, in <module>
    from mbed import main
ImportError: cannot import name 'main'
```
The fix is to add a dot to the import in \_\_main\_\_.py to tell python to search current package before rest of PYTHONPATH.