### PR TITLE
change test to generic tests due to integration test got removed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ commands:
                 command: |
                     echo $PATH
                     ls -l /opt/gcc-arm-none-eabi-5_3-2016q1/bin
-                    mbed compile --source=. --source=mbed-os/TESTS/integration/basic -j 0
-                    mbed test --compile -n mbed-os-tests-integration-basic -j 0
+                    mbed compile --source=. --source=mbed-os/TESTS/mbed_drivers/generic_tests -j 0
+                    mbed test --compile -n mbed-os-tests-mbed_drivers-generic_tests -j 0
     run_old_support_tests:
         steps:
             - run:


### PR DESCRIPTION
`integration-basic` test got removed from mbed-os, Change the test in Circle CI to `generic_tests`