### PR TITLE
IOTBTOOL-400: Fix mbed add in python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(
     install_requires=[
         "pyserial>=3.0,<4.0",
         "mbed-os-tools>=0.0.9,<0.1.0",
+        "mercurial>=5.2"
     ]
 )


### PR DESCRIPTION
```mbed add``` command would fail if trying to pull a mercurial repo since
mercurial is not in the requirements list. Added it (now supports py3)