### PR TITLE
Allow developers to use branch-names in lib-files.

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -1081,8 +1081,6 @@ class Repo(object):
 
         if m_repo_ref:
             rev = m_repo_ref.group(3)
-            if rev and rev != 'latest' and rev != 'tip' and not re.match(r'^([a-fA-F0-9]{6,40})$', rev):
-                error('Named branches not allowed in .lib, offending lib is {} '.format(os.path.basename(lib)))
 
         if not (m_local or m_bld_ref or m_repo_ref):
             warning(


### PR DESCRIPTION
This limitation in the tool is quite artificial and causes significant
issues for development which can span multiple repositories and branches.

Allowing this would simplify maintenance of development branches with
interdependencies.