### PR TITLE
Remove warning about Python 3

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -3427,10 +3427,6 @@ def main():
         log(ver+"\n")
         sys.exit(0)
 
-    # Python 3 backwards compatability warning
-    if sys.version_info[0] == 3:
-        warning("Python 3 is not yet fully supported: Python errors may occur when compiling, testing and exporting")
-
     pargs, remainder = parser.parse_known_args()
     status = 1
 


### PR DESCRIPTION
Tools should now support Python 3, although old versions of mbed-os will still not work as the tools are baked into the OS.