### PR TITLE
Fix link to README broken in #937

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Mbed CLI supports both Git and Mercurial repositories, so you'll also need to in
 
 Get Started
 ===========
-The best way to get started is to `read the documentation on GitHub <https://github.com/ARMmbed/mbed-cli/blob/master/README.md>`_.
+The best way to get started is to `read the documentation on GitHub <https://github.com/ARMmbed/mbed-cli/blob/master/README.rst>`_.
 
 License
 =======


### PR DESCRIPTION
The [PyPI project description](https://pypi.org/project/mbed-cli/1.10.2/#description) has a broken link because `README.md` was renamed to `README.rst` in #937 but the link was not updated.  

cc @mark-edgeworth @madchutney