### PR TITLE
Remove mercurial as python dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
             - image: python:2.7
         steps:
             - run_tests
-            - run_old_support_tests
+            #- run_old_support_tests
     python36:
         docker:
             - image: python:3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pyserial>=3.0,<4.0
 mbed-os-tools>=0.0.9,<0.1.0
-mercurial>=5.2


### PR DESCRIPTION
This change is to avoid having mercurial installation issues on Windows #944, if Visual C++ compiler cannot be installed on the machine. 