### PR TITLE
mbed compile : enable flash option with dual core targets

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2785,6 +2785,10 @@ def compile_(toolchain=None, target=None, macro=False, profile=False,
                     error("The '-f/--flash' option requires that the 'mbed-greentea' python module is installed.\nYou can install mbed-greentea by running \"%s -m pip install mbed-greentea\"." % python_cmd, 1)
 
                 connected = False
+                # Convert Dual Core target name to mbedls target name
+                if target.upper().endswith('_CM4') or target.upper().endswith('_CM7'):
+                    target = target[:-4]
+                    action('Target to detect: %s' % target)
                 targets = program.get_detected_targets()
                 if targets:
                     for _target in targets:


### PR DESCRIPTION
mbed compile -m DISCO_H747I_CM4 -t ARM -f
is using mbedls result to detect the correct plugged target on host.

There is an issue with dual core chips,
because 2 different targets exist in the targets.json file for the same HW

Associated patch for mbed test command:
https://github.com/ARMmbed/mbed-os/pull/12630

@MarceloSalazar 
@LMESTM

