### PR TITLE
Fix UT --valgrind command

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -2901,7 +2901,7 @@ def test_(toolchain=None, target=None, macro=False, compile_list=False, run_list
                         + (["--clean"] if clean else [])
                         + (["--debug"] if profile and "debug" in profile else [])
                         + (["--coverage", coverage] if coverage else [])
-                        + (["--valgrind", valgrind] if valgrind else [])
+                        + (["--valgrind"] if valgrind else [])
                         + (["--make-program", make_program] if make_program else [])
                         + (["--generator", generator] if generator else [])
                         + (["--regex", regex] if regex else [])


### PR DESCRIPTION
Fixes the problem where `mbed test --unittests --valgrind` fails to error
`[mbed] ERROR: Unknown Error: sequence item 3: expected str instance, bool found`
