### PR TITLE
Python3 compatibility fix for end of urlopen read

### DIFF
--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -394,7 +394,7 @@ class Bld(object):
                 inurl = urlopen(url)
                 with open(rev_file, 'wb') as outfd:
                     data = None
-                    while data != '':
+                    while data != b'':
                         # Download and write the data in 1 MB chunks
                         data = inurl.read(1024 * 1024)
                         outfd.write(data)


### PR DESCRIPTION
Fixes #968. Context:

```
(base) arvoelke@abr09:~/git/mbed-cli/mbed$ python2 -c "print('' == b'')"
True
(base) arvoelke@abr09:~/git/mbed-cli/mbed$ python3 -c "print('' == b'')"
False
```

Hence the check used to work on Py2 only (for Py3, it would enter an infinite loop after hitting the end of the file). It should now work on both Py2 and Py3.