### PR TITLE
Change Mbed CLI README link to os.mbed.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Mbed CLI supports both Git and Mercurial repositories, so you'll also need to in
 
 Get Started
 ===========
-The best way to get started is to `read the documentation on GitHub <https://github.com/ARMmbed/mbed-cli/blob/master/README.rst>`_.
+The best way to get started is to `read the documentation on os.mbed.com <https://os.mbed.com/docs/mbed-os/latest/build-tools/mbed-cli.html>`_.
 
 License
 =======


### PR DESCRIPTION
I propose changing the "Get Started" link to point to where the actual Mbed CLI docs are stored. I was navigated to the GitHub `README.rst` page when I searched for the pip Mbed-cli package page: https://pypi.org/project/mbed-cli/ and found that the only documentation link available on this page was to this same `README.rst` that wasn't useful for "Getting Started with Mbed CLI".