### PR TITLE
Don't require too old mbed-os-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
                 command: |
                     echo $PATH
                     ls -l /opt/gcc-arm-none-eabi-5_3-2016q1/bin
-                    mbed compile --source=. --source=mbed-os/TESTS/mbed_drivers/generic_tests -j 0
+                    mbed compile --source=. --source=mbed-os/drivers/tests/TESTS/mbed_drivers/generic_tests -j 0
                     mbed test --compile -n mbed-os-tests-mbed_drivers-generic_tests -j 0
     run_old_support_tests:
         steps:

--- a/mbed/mbed.py
+++ b/mbed/mbed.py
@@ -53,7 +53,7 @@ from contextlib import contextmanager
 
 
 # Application version
-ver = '1.10.4'
+ver = '1.10.5'
 
 # Default paths to Mercurial and Git
 hg_cmd = 'hg'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyserial>=3.0,<4.0
-mbed-os-tools>=0.0.9,<0.1.0
+mbed-os-tools>=0.0.9

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 NAME = 'mbed-cli'
-__version__ = '1.10.4'
+__version__ = '1.10.5'
 
 repository_dir = os.path.dirname(__file__)
 


### PR DESCRIPTION
mbed-os-tools 1.8.0 is as compatible with 0.0.9 as 0.0.15 was. Remove
the "not greater than" bound on the mbed-os-tools version.